### PR TITLE
feat(frontend): React web UI prototype on mock data

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.vite
+*.tsbuildinfo
+.DS_Store

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,75 @@
+# frontend — Privacy HUD web UI (prototype, mock data)
+
+A React front-end for the Level 2 / Level 3 surfaces of Privacy HUD, plus the
+consent prompt of the live block flow. Styled after openai.com: white ground,
+near-black ink, hairline borders, pill buttons; green only for *allowed*, red
+only for *blocked*.
+
+**Status: UI prototype on mock data.** Nothing in this folder reads the ledger
+or talks to the daemon yet. `ui/index.html` + `ui/app.js` remain the UI the
+`$privacy` skill actually serves. This folder is a proposal for what that UI
+could grow into, with the data model kept close to the existing endpoints so
+wiring it is a swap of one module, not a rewrite.
+
+## Run
+
+```bash
+cd frontend
+npm install
+npm run dev        # http://localhost:5173, localhost only
+npm run build      # type-check + bundle into frontend/dist/ (relative paths)
+```
+
+To point the dev server's `/api/*` calls at a running `local_ui_server.py`,
+pass the URL the `$privacy` skill prints:
+
+```bash
+VITE_API_TARGET=http://127.0.0.1:51234 npm run dev
+```
+
+(The proxy exists so the wiring step has somewhere to land; no screen calls
+`/api` today.)
+
+## What is in the prototype
+
+| Route (hash-routed) | Screen                                                                 |
+| ------------------- | ---------------------------------------------------------------------- |
+| `#/`                | Landing page explaining the model: data → policy gate → agents and apps |
+| `#/app`             | Overview: counts, recent flows, open alerts, one agent suggestion        |
+| `#/app/data`        | Data vault: fields with provenance (websites, Codex / Claude Code sessions, browser) |
+| `#/app/apps`        | Destinations by category, declared scopes coloured by the effective policy, "Explain" drawer |
+| `#/app/rules`       | Plain-language rule composer (keyword parser), rule list, suggestions    |
+| `#/app/activity`    | Flow log: agent, session, destination, fields, decision, rule; raw request on expand |
+| `#/app/alerts`      | Critical / warning / info alerts with a resolve action                  |
+
+"Simulate agent request" in the top bar cycles through `SCENARIOS` in
+`src/data/mock.ts`. Each one runs through `src/store/engine.ts`: secrets are
+always blocked, unverified destinations are blocked, a destination asking
+beyond its declared scopes is flagged, otherwise the most specific rule wins
+(app › agent › category › everything) and the stricter effect wins a tie.
+Outcomes surface as a consent modal, a red takeover for a blocked secret, or a
+toast, and every outcome lands in the activity log.
+
+## Mapping onto the existing backend
+
+| Prototype concept                    | Existing counterpart                                        |
+| ------------------------------------ | ----------------------------------------------------------- |
+| Activity row (`ShareEvent`)          | ledger event row from `GET /api/exposures?tab=…`             |
+| Overview counts                      | `GET /api/summary`                                           |
+| Activity row expanded                | `GET /api/detail?id=…`                                       |
+| Rule with effect `deny` / `ask`      | `POST /api/policy` (`rule_type`, `selector`)                 |
+| Consent modal (Allow once / Deny)    | the live `PreToolUse` block flow, **not** the audit server (see `local_ui_server.py` docstring: the ledger never stores `tool_input`, so "Allow once" cannot be minted from historical rows) |
+| Alerts, data vault, app catalogue    | no counterpart yet; mock only                                |
+
+Wording to keep when wiring: the ledger records *flows*, not findings, and
+disclosed data cannot be recalled. The prototype's copy avoids "undo",
+"revoke" and "remove from context" for that reason; keep it that way.
+
+## Layout
+
+- `src/data/types.ts`, `src/data/mock.ts` — data model and all mock data. `BRAND` is the product name shown everywhere.
+- `src/store/engine.ts` — decision engine, keyword rule parser, per-app explanation text.
+- `src/store/store.tsx` — React reducer: apps, rules, events, alerts, pending prompt, takeover, toasts.
+- `src/components/` — shell, overlays (consent modal, takeover, drawer, toasts), icons, primitives.
+- `src/pages/` — one file per route.
+- `src/styles/global.css` — design tokens and all styles, no CSS framework.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scope — The OAuth layer for your data and AI agents</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='8' fill='%230d0d0d'/%3E%3Ccircle cx='16' cy='16' r='7' fill='none' stroke='%23fff' stroke-width='2.5'/%3E%3Ccircle cx='16' cy='16' r='2.5' fill='%2310a37f'/%3E%3C/svg%3E" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:ital,wght@0,300..800;1,300..800&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1834 @@
+{
+  "name": "scope",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scope",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.28.0"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.11"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.27.tgz",
+      "integrity": "sha512-79Iho8QeYyooJ8e9lCRyTVlyTAkS/kXBYKff6TMzS3kEWGQ8Ds5UEtXpGrSUDLUWok6QTvxeYy0GO8fopHnaSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "scope",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,38 @@
+import { HashRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { useEffect } from 'react'
+import { Shell } from './components/Shell'
+import { StoreProvider } from './store/store'
+import Landing from './pages/Landing'
+import Overview from './pages/Overview'
+import Data from './pages/Data'
+import Apps from './pages/Apps'
+import Rules from './pages/Rules'
+import Activity from './pages/Activity'
+import Alerts from './pages/Alerts'
+
+function ScrollTop() {
+  const { pathname } = useLocation()
+  useEffect(() => { window.scrollTo(0, 0) }, [pathname])
+  return null
+}
+
+export default function App() {
+  return (
+    <HashRouter>
+      <ScrollTop />
+      <StoreProvider>
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/app" element={<Shell />}>
+            <Route index element={<Overview />} />
+            <Route path="data" element={<Data />} />
+            <Route path="apps" element={<Apps />} />
+            <Route path="rules" element={<Rules />} />
+            <Route path="activity" element={<Activity />} />
+            <Route path="alerts" element={<Alerts />} />
+          </Route>
+        </Routes>
+      </StoreProvider>
+    </HashRouter>
+  )
+}

--- a/frontend/src/components/Icon.tsx
+++ b/frontend/src/components/Icon.tsx
@@ -1,0 +1,59 @@
+const P: Record<string, string> = {
+  shield: 'M12 3l7 3v5c0 5-3.5 8.5-7 10-3.5-1.5-7-5-7-10V6l7-3z',
+  database: 'M4 6c0-1.7 3.6-3 8-3s8 1.3 8 3-3.6 3-8 3-8-1.3-8-3zM4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3',
+  grid: 'M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z',
+  sliders: 'M4 6h10M18 6h2M4 12h2M10 12h10M4 18h12M20 18h0M14 4v4M6 10v4M16 16v4',
+  activity: 'M3 12h4l3-8 4 16 3-8h4',
+  bell: 'M6 16V11a6 6 0 0 1 12 0v5l2 2H4l2-2zM10 20a2 2 0 0 0 4 0',
+  check: 'M5 12l5 5L20 7',
+  x: 'M6 6l12 12M18 6L6 18',
+  alert: 'M12 3l10 18H2L12 3zM12 10v4M12 17.5v.5',
+  eye: 'M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12zM12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z',
+  eyeOff: 'M3 3l18 18M10.6 10.6A3 3 0 0 0 13.4 13.4M9.9 5.2A10.5 10.5 0 0 1 12 5c6 0 10 7 10 7a17 17 0 0 1-3 3.6M6.6 6.6C3.7 8.6 2 12 2 12s4 7 10 7c1.6 0 3-.4 4.3-1',
+  arrowRight: 'M5 12h14M13 6l6 6-6 6',
+  arrowUpRight: 'M7 17L17 7M8 7h9v9',
+  plus: 'M12 5v14M5 12h14',
+  search: 'M11 4a7 7 0 1 0 0 14 7 7 0 0 0 0-14zM20 20l-4-4',
+  sparkle: 'M12 3l1.8 5.2L19 10l-5.2 1.8L12 17l-1.8-5.2L5 10l5.2-1.8L12 3zM19 16l.7 2 2 .7-2 .7-.7 2-.7-2-2-.7 2-.7.7-2z',
+  terminal: 'M4 17l6-5-6-5M12 19h8',
+  lock: 'M6 11h12v9H6zM9 11V8a3 3 0 0 1 6 0v3',
+  globe: 'M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zM3 12h18M12 3c3 3 3 15 0 18M12 3c-3 3-3 15 0 18',
+  chevronDown: 'M6 9l6 6 6-6',
+  chevronRight: 'M9 6l6 6-6 6',
+  trash: 'M4 7h16M9 7V4h6v3M6 7l1 13h10l1-13',
+  info: 'M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zM12 11v5M12 8v.5',
+  refresh: 'M20 12a8 8 0 1 1-2.3-5.7M20 4v5h-5',
+  zap: 'M13 2L4 14h7l-1 8 9-12h-7l1-8z',
+  play: 'M7 5l12 7-12 7z',
+  user: 'M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM4 21a8 8 0 0 1 16 0',
+  clock: 'M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18zM12 7v5l3 2',
+  key: 'M14 4a6 6 0 0 0-5.7 7.9L3 17.2V21h4l1-1v-2h2l1-1v-2h2l.9-.9A6 6 0 1 0 14 4zM15 9h.5',
+  filter: 'M4 5h16l-6 8v6l-4-2v-4L4 5z',
+  code: 'M8 6l-6 6 6 6M16 6l6 6-6 6',
+  logout: 'M10 4H5v16h5M14 8l5 4-5 4M19 12H9',
+  download: 'M12 4v11M7 10l5 5 5-5M4 20h16',
+  layers: 'M12 3l9 5-9 5-9-5 9-5zM3 13l9 5 9-5',
+  plane: 'M10 20l1-6-7-2 16-9-5 15-3-3-2 5z',
+  tv: 'M3 6h18v11H3zM8 21h8',
+  bag: 'M5 8h14l-1 12H6L5 8zM9 8V6a3 3 0 0 1 6 0v2',
+  card: 'M3 6h18v12H3zM3 10h18M7 15h3',
+  heart: 'M12 20s-7-4.4-7-10a4 4 0 0 1 7-2.6A4 4 0 0 1 19 10c0 5.6-7 10-7 10z',
+  doc: 'M6 3h9l4 4v14H6zM15 3v4h4M9 12h6M9 16h6',
+  users: 'M9 12a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7zM2 20a7 7 0 0 1 14 0M16 5a3.5 3.5 0 0 1 0 7M18 13a6 6 0 0 1 4 7',
+  monitor: 'M3 5h18v11H3zM8 20h8M12 16v4',
+  cloud: 'M7 18a4 4 0 0 1-.5-8A6 6 0 0 1 18 9a4 4 0 0 1 0 9H7z',
+  dot: 'M12 12h.01',
+}
+
+export type IconName = keyof typeof P
+
+export function Icon({ name, size = 18, stroke = 1.75, className, style }: {
+  name: IconName; size?: number; stroke?: number; className?: string; style?: React.CSSProperties
+}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={stroke}
+      strokeLinecap="round" strokeLinejoin="round" className={className} style={{ flex: 'none', ...style }} aria-hidden>
+      <path d={P[name]} />
+    </svg>
+  )
+}

--- a/frontend/src/components/Overlays.tsx
+++ b/frontend/src/components/Overlays.tsx
@@ -1,0 +1,195 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Icon } from './Icon'
+import { AgentBadge, AppAvatar, CategoryTag, Sens, Toggle, TrustTag } from './ui'
+import { useStore } from '../store/store'
+import { BRAND, DATA } from '../data/mock'
+import { DATA_CATEGORIES } from '../data/types'
+import { explainApp } from '../store/engine'
+
+export function Overlays() {
+  return <><ConsentPrompt /><Takeover /><AppDrawer /><Toasts /></>
+}
+
+function ConsentPrompt() {
+  const { pending, apps, dispatch } = useStore()
+  if (!pending) return null
+  const { scenario, evaluation } = pending
+  const app = apps.find(a => a.id === scenario.app)!
+  const asking = evaluation.fields.filter(f => f.effect === 'ask').length
+  return (
+    <div className="overlay">
+      <div className="modal" role="dialog" aria-modal>
+        <div className="head">
+          <div className="row" style={{ justifyContent: 'space-between' }}>
+            <AgentBadge agent={scenario.agent} />
+            <span className="tag"><Icon name="clock" size={11} />Waiting for you</span>
+          </div>
+          <h2 style={{ fontSize: 24, marginTop: 18, lineHeight: 1.15 }}>
+            Share with {app.name}?
+          </h2>
+          <p className="sub" style={{ marginTop: 8 }}>
+            Session <span className="mono">{scenario.session}</span> · {scenario.context}
+          </p>
+        </div>
+        <div className="body">
+          <div className="row" style={{ marginBottom: 12 }}>
+            <AppAvatar app={app} size="sm" />
+            <div className="grow">
+              <div style={{ fontWeight: 500 }}>{app.name}</div>
+              <div className="muted" style={{ fontSize: 12.5 }}>{app.domain}</div>
+            </div>
+            <TrustTag trust={app.trust} />
+          </div>
+          <div className="card" style={{ padding: '4px 16px' }}>
+            {evaluation.fields.map(f => (
+              <div className="consent-row" key={f.item.id}>
+                <div className="grow">
+                  <div className="row" style={{ gap: 8 }}>
+                    <span style={{ fontWeight: 500 }}>{f.item.label}</span>
+                    <span className="mono muted">{f.item.value}</span>
+                  </div>
+                  <div className="muted" style={{ fontSize: 12.5, marginTop: 2 }}>{f.reason}</div>
+                </div>
+                {f.effect === 'allow' && <span className="tag green"><Icon name="check" size={11} stroke={2.5} />{f.ruleId}</span>}
+                {f.effect === 'ask' && <span className="tag amber">Needs approval</span>}
+                {f.effect === 'deny' && <span className="tag red"><Icon name="x" size={11} stroke={2.5} />{f.ruleId}</span>}
+              </div>
+            ))}
+          </div>
+          <p className="muted" style={{ fontSize: 12.5, marginTop: 12 }}>
+            {asking} field{asking > 1 ? 's' : ''} need{asking > 1 ? '' : 's'} your approval. Nothing has been sent yet. Your decision is logged in Activity.
+          </p>
+        </div>
+        <div className="foot">
+          <button className="btn ghost" onClick={() => dispatch({ type: 'resolvePending', decision: 'deny' })}>Deny</button>
+          <button className="btn soft" onClick={() => dispatch({ type: 'resolvePending', decision: 'allow' })}>Allow once</button>
+          <button className="btn" onClick={() => dispatch({ type: 'resolvePending', decision: 'always' })}>Always allow for {app.name}</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Takeover() {
+  const { criticalTakeover, events, apps, dispatch } = useStore()
+  const nav = useNavigate()
+  if (!criticalTakeover) return null
+  const ev = events.find(e => e.id === criticalTakeover.eventId)
+  const app = ev && apps.find(a => a.id === ev.app)
+  return (
+    <div className="overlay" style={{ background: 'rgba(120,10,14,.5)' }}>
+      <div className="modal critical" role="alertdialog" aria-modal>
+        <div className="head">
+          <div className="row" style={{ gap: 16 }}>
+            <div className="big-x"><Icon name="alert" size={28} stroke={2.2} /></div>
+            <div>
+              <div className="eyebrow" style={{ color: 'var(--red)' }}>Blocked before leaving your machine</div>
+              <h2 style={{ fontSize: 22, marginTop: 4, lineHeight: 1.2 }}>{criticalTakeover.title}</h2>
+            </div>
+          </div>
+        </div>
+        <div className="body">
+          <p className="sub">{criticalTakeover.body}</p>
+          {ev && app && (
+            <div className="card soft" style={{ padding: 14, marginTop: 16 }}>
+              <div className="row" style={{ justifyContent: 'space-between', marginBottom: 10 }}>
+                <AgentBadge agent={ev.agent} />
+                <span className="muted" style={{ fontSize: 13 }}>→ {app.domain}</span>
+              </div>
+              {ev.fields.map(id => DATA.find(d => d.id === id)).filter(Boolean).map(d => (
+                <div className="between" key={d!.id} style={{ padding: '6px 0', borderTop: '1px solid var(--line)' }}>
+                  <span className="row" style={{ gap: 8 }}><span className="mono">{d!.label}</span><CategoryTag cat={d!.category} /></span>
+                  <Sens level={d!.sensitivity} />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="foot">
+          <button className="btn ghost" onClick={() => dispatch({ type: 'dismissTakeover' })}>Dismiss</button>
+          <button className="btn danger" onClick={() => { dispatch({ type: 'dismissTakeover' }); nav('/app/alerts') }}>Review alert</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AppDrawer() {
+  const { drawerApp, apps, rules, dispatch } = useStore()
+  const app = apps.find(a => a.id === drawerApp)
+  useEffect(() => {
+    if (!app) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') dispatch({ type: 'drawer', id: null }) }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [app, dispatch])
+  if (!app) return null
+  const ex = explainApp(app, rules)
+  return (
+    <>
+      <div className="overlay" style={{ background: 'rgba(13,13,13,.2)', backdropFilter: 'none' }} onClick={() => dispatch({ type: 'drawer', id: null })} />
+      <aside className="drawer">
+        <div className="dh">
+          <AppAvatar app={app} />
+          <div className="grow">
+            <div style={{ fontWeight: 600 }}>{app.name}</div>
+            <div className="muted" style={{ fontSize: 12.5 }}>{app.domain}</div>
+          </div>
+          <TrustTag trust={app.trust} />
+          <button className="bell" style={{ width: 34, height: 34 }} onClick={() => dispatch({ type: 'drawer', id: null })} aria-label="Close"><Icon name="x" size={16} /></button>
+        </div>
+        <div className="db">
+          <div className="explain">
+            <div className="who"><Icon name="sparkle" size={13} />Explained by the {BRAND} agent</div>
+            {ex.text}
+          </div>
+          <div>
+            <div className="h-sec" style={{ marginBottom: 10 }}>Declared scopes</div>
+            <div className="card">
+              <div className="list">
+                {ex.rows.length === 0 && <div className="empty">This app declares no scopes.</div>}
+                {ex.rows.map(r => (
+                  <div className="item" key={r.cat}>
+                    <div className="grow">
+                      <div className="t">{DATA_CATEGORIES[r.cat].label}</div>
+                      <div className="s">{DATA_CATEGORIES[r.cat].hint}</div>
+                    </div>
+                    <span className={`scope ${r.effect}`}>{r.effect === 'allow' ? 'Shared' : r.effect === 'ask' ? 'Ask me' : 'Never'}{r.rule && <span className="mono" style={{ fontSize: 11 }}>{r.rule.id}</span>}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+          <div className="card pad between">
+            <div>
+              <div style={{ fontWeight: 500 }}>Connected</div>
+              <div className="muted" style={{ fontSize: 12.5 }}>{app.connected ? `${app.requests} requests so far` : 'Agents cannot share anything until connected'}</div>
+            </div>
+            <Toggle on={app.connected} onChange={() => dispatch({ type: 'toggleApp', id: app.id })} green />
+          </div>
+        </div>
+      </aside>
+    </>
+  )
+}
+
+function Toasts() {
+  const { toasts, dispatch } = useStore()
+  useEffect(() => {
+    if (!toasts.length) return
+    const t = setTimeout(() => dispatch({ type: 'untoast', id: toasts[0].id }), 3600)
+    return () => clearTimeout(t)
+  }, [toasts, dispatch])
+  if (!toasts.length) return null
+  return (
+    <div className="toasts">
+      {toasts.map(t => (
+        <div className="toast" key={t.id}>
+          <span style={{ width: 8, height: 8, borderRadius: 4, background: t.tone === 'ok' ? 'var(--green)' : t.tone === 'bad' ? 'var(--red)' : '#fff', flex: 'none' }} />
+          <div><div>{t.title}</div>{t.sub && <div className="s">{t.sub}</div>}</div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/Shell.tsx
+++ b/frontend/src/components/Shell.tsx
@@ -1,0 +1,92 @@
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
+import { Icon, type IconName } from './Icon'
+import { BRAND, USER } from '../data/mock'
+import { useStore } from '../store/store'
+import { Overlays } from './Overlays'
+
+const NAV: { to: string; label: string; icon: IconName; end?: boolean }[] = [
+  { to: '/app', label: 'Overview', icon: 'grid', end: true },
+  { to: '/app/data', label: 'My data', icon: 'database' },
+  { to: '/app/apps', label: 'Applications', icon: 'layers' },
+  { to: '/app/rules', label: 'Rules', icon: 'sliders' },
+  { to: '/app/activity', label: 'Activity', icon: 'activity' },
+  { to: '/app/alerts', label: 'Alerts', icon: 'bell' },
+]
+
+export function BrandMark({ size = 28 }: { size?: number }) {
+  return (
+    <span className="brand-mark" style={{ width: size, height: size, borderRadius: size * 0.29 }}>
+      <svg width={size * 0.6} height={size * 0.6} viewBox="0 0 24 24" fill="none">
+        <circle cx="12" cy="12" r="7.5" stroke="#fff" strokeWidth="2.4" />
+        <circle cx="12" cy="12" r="2.6" fill="#10a37f" />
+      </svg>
+    </span>
+  )
+}
+
+export function Shell() {
+  const { unresolved, simulate, alerts, events } = useStore()
+  const loc = useLocation()
+  const nav = useNavigate()
+  const title = NAV.find(n => n.end ? loc.pathname === n.to : loc.pathname.startsWith(n.to))?.label ?? 'Overview'
+  const critical = alerts.find(a => a.severity === 'critical' && !a.resolved)
+  const pendingCount = events.filter(e => e.decision === 'pending').length
+
+  return (
+    <div className="shell">
+      <aside className="side">
+        <NavLink to="/" className="brand"><BrandMark />{BRAND}</NavLink>
+        <div className="eyebrow nav-label">Workspace</div>
+        {NAV.map(n => (
+          <NavLink key={n.to} to={n.to} end={n.end} className={({ isActive }) => `navi ${isActive ? 'active' : ''}`}>
+            <Icon name={n.icon} size={17} />
+            {n.label}
+            {n.to === '/app/alerts' && unresolved.length > 0 && <span className="count red">{unresolved.length}</span>}
+            {n.to === '/app/activity' && pendingCount > 0 && <span className="count">{pendingCount} pending</span>}
+          </NavLink>
+        ))}
+        <div className="eyebrow nav-label">Plugins</div>
+        <div className="navi" style={{ cursor: 'default' }}><span className="agent"><span className="ic codex">CX</span></span>Codex <span className="count" style={{ color: 'var(--green)' }}>● live</span></div>
+        <div className="navi" style={{ cursor: 'default' }}><span className="agent"><span className="ic claude">CC</span></span>Claude Code <span className="count" style={{ color: 'var(--green)' }}>● live</span></div>
+        <div className="navi" style={{ cursor: 'default' }}><span className="agent"><span className="ic chatgpt">GP</span></span>ChatGPT agent <span className="count">idle</span></div>
+        <div className="me">
+          <div className="avatar sm" style={{ background: 'linear-gradient(135deg,#10a37f,#0d0d0d)' }}>{USER.name.split(' ').map(w => w[0]).join('')}</div>
+          <div className="grow">
+            <div style={{ fontWeight: 500, fontSize: 13.5 }}>{USER.name}</div>
+            <div className="muted" style={{ fontSize: 12 }}>{USER.plan} plan</div>
+          </div>
+          <Icon name="logout" size={16} className="muted" />
+        </div>
+      </aside>
+
+      <div className="main">
+        <header className="topbar">
+          <div className="crumb">{BRAND} <Icon name="chevronRight" size={14} /> <b>{title}</b></div>
+          <div className="grow" />
+          <div className="field" style={{ width: 260, height: 36 }}>
+            <Icon name="search" size={15} className="muted" />
+            <input placeholder="Search data, apps, rules…" />
+            <span className="kbd">⌘K</span>
+          </div>
+          <button className="btn" onClick={simulate}><Icon name="zap" size={15} stroke={2.2} />Simulate agent request</button>
+          <button className="bell" onClick={() => nav('/app/alerts')} aria-label="Alerts">
+            <Icon name="bell" size={17} />
+            {unresolved.length > 0 && <span className="n">{unresolved.length}</span>}
+          </button>
+        </header>
+
+        <main className="content">
+          {critical && (
+            <div className="banner critical">
+              <span className="pulse" />
+              <div className="grow"><b>Critical.</b> {critical.title}</div>
+              <button className="btn" onClick={() => nav('/app/alerts')}>Review</button>
+            </div>
+          )}
+          <Outlet />
+        </main>
+      </div>
+      <Overlays />
+    </div>
+  )
+}

--- a/frontend/src/components/ui.tsx
+++ b/frontend/src/components/ui.tsx
@@ -1,0 +1,70 @@
+import { Icon, type IconName } from './Icon'
+import { AGENTS, DATA_CATEGORIES, type AgentId, type App, type AppCategoryId, type DataCategory, type Decision, type Sensitivity, type Source } from '../data/types'
+
+export function AppAvatar({ app, size = '' }: { app: App; size?: '' | 'sm' | 'lg' }) {
+  const initials = app.name.replace(/\.[a-z]+$/i, '').split(/[\s-]/).map(w => w[0]).join('').slice(0, 2).toUpperCase()
+  return <div className={`avatar ${size}`} style={{ background: app.color }}>{initials}</div>
+}
+
+export function AgentBadge({ agent, compact = false }: { agent: AgentId; compact?: boolean }) {
+  const a = AGENTS[agent]
+  return (
+    <span className="agent">
+      <span className={`ic ${a.cls}`}>{a.short}</span>
+      {!compact && a.label}
+    </span>
+  )
+}
+
+export function DecisionBadge({ d }: { d: Decision }) {
+  const label: Record<Decision, string> = { allowed: 'Allowed', denied: 'Denied', asked: 'Asked', blocked: 'Blocked', pending: 'Awaiting you' }
+  return <span className={`decision ${d}`}><i />{label[d]}</span>
+}
+
+export function Toggle({ on, onChange, green }: { on: boolean; onChange: () => void; green?: boolean }) {
+  return <button type="button" role="switch" aria-checked={on} className={`toggle ${on ? 'on' : ''} ${green ? 'green' : ''}`} onClick={onChange} />
+}
+
+export function CategoryTag({ cat }: { cat: DataCategory }) {
+  return <span className="tag outline">{DATA_CATEGORIES[cat].label}</span>
+}
+
+export function Sens({ level }: { level: Sensitivity }) {
+  return <span className={`sens ${level}`}><i />{level[0].toUpperCase() + level.slice(1)}</span>
+}
+
+const KIND_ICON: Record<Source['kind'], IconName> = { website: 'globe', codex: 'terminal', 'claude-code': 'terminal', browser: 'monitor' }
+export function SourceBadge({ source }: { source: Source }) {
+  return (
+    <span className="row" style={{ gap: 8, fontSize: 13.5 }}>
+      <span style={{ width: 22, height: 22, borderRadius: 6, background: source.color, display: 'grid', placeItems: 'center', color: '#fff' }}>
+        <Icon name={KIND_ICON[source.kind]} size={12} stroke={2.2} />
+      </span>
+      <span className="trunc">{source.name}</span>
+    </span>
+  )
+}
+
+export const CAT_ICON: Record<AppCategoryId, IconName> = {
+  travel: 'plane', streaming: 'tv', shopping: 'bag', finance: 'card', health: 'heart', productivity: 'doc', social: 'users', developer: 'code',
+}
+
+export function TrustTag({ trust }: { trust: App['trust'] }) {
+  if (trust === 'verified') return <span className="tag green"><Icon name="check" size={11} stroke={2.5} />Verified</span>
+  if (trust === 'community') return <span className="tag">Community</span>
+  return <span className="tag red"><Icon name="alert" size={11} stroke={2.5} />Unverified</span>
+}
+
+export function Stat({ label, value, delta, tone }: { label: string; value: string | number; delta?: string; tone?: 'red' | 'green' }) {
+  return (
+    <div className="stat">
+      <div className="label">{label}</div>
+      <div className="val">{value}</div>
+      {delta && <div className={`delta ${tone ?? ''}`}>{delta}</div>}
+    </div>
+  )
+}
+
+export function Empty({ text }: { text: string }) {
+  return <div className="empty">{text}</div>
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,17 @@
+export function timeAgo(iso: string) {
+  const diff = Math.max(0, Date.now() - new Date(iso).getTime())
+  const m = Math.round(diff / 60_000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m} min ago`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h} h ago`
+  const d = Math.round(h / 24)
+  if (d === 1) return 'yesterday'
+  if (d < 30) return `${d} days ago`
+  return `${Math.round(d / 30)} mo ago`
+}
+export const fmtTime = (iso: string) =>
+  new Date(iso).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' })
+export const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+export const fmtDateTime = (iso: string) => `${fmtDate(iso)} · ${fmtTime(iso)}`

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import { BRAND } from './data/mock'
+import './styles/global.css'
+
+document.title = `${BRAND} — The OAuth layer for your data and AI agents`
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/src/pages/Activity.tsx
+++ b/frontend/src/pages/Activity.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import { Icon } from '../components/Icon'
+import { AgentBadge, AppAvatar, CategoryTag, DecisionBadge } from '../components/ui'
+import { DATA } from '../data/mock'
+import { AGENTS, type AgentId, type Decision } from '../data/types'
+import { fmtDate, fmtTime } from '../lib/format'
+import { useStore } from '../store/store'
+
+type DF = 'all' | Decision
+const FILTERS: { id: DF; label: string }[] = [
+  { id: 'all', label: 'All' }, { id: 'allowed', label: 'Allowed' }, { id: 'pending', label: 'Pending' }, { id: 'asked', label: 'Asked' }, { id: 'denied', label: 'Denied' }, { id: 'blocked', label: 'Blocked' },
+]
+
+export default function Activity() {
+  const { events, apps, simulate } = useStore()
+  const [f, setF] = useState<DF>('all')
+  const [agent, setAgent] = useState<AgentId | null>(null)
+  const [open, setOpen] = useState<string | null>(null)
+  const shown = events.filter(e => (f === 'all' || e.decision === f) && (!agent || e.agent === agent))
+  const stopped = events.filter(e => e.decision === 'denied' || e.decision === 'blocked').length
+
+  return (
+    <>
+      <div className="page-head">
+        <div>
+          <h1 className="h-page">Activity</h1>
+          <p>Every share request from your agents, with the fields involved, the rule that decided, and what you did. {events.length} requests, {stopped} stopped.</p>
+        </div>
+        <button className="btn ghost" onClick={simulate}><Icon name="zap" size={15} />Simulate agent request</button>
+      </div>
+
+      <div className="between">
+        <div className="seg">
+          {FILTERS.map(x => <button key={x.id} className={f === x.id ? 'on' : ''} onClick={() => setF(x.id)}>{x.label}</button>)}
+        </div>
+        <div className="chips">
+          {(Object.keys(AGENTS) as AgentId[]).map(a => (
+            <button key={a} className={`chip ${agent === a ? 'on' : ''}`} onClick={() => setAgent(agent === a ? null : a)}>{AGENTS[a].label}</button>
+          ))}
+        </div>
+      </div>
+
+      <div className="card" style={{ overflow: 'hidden' }}>
+        <div className="list">
+          {shown.length === 0 && <div className="empty">No requests match.</div>}
+          {shown.map(e => {
+            const app = apps.find(a => a.id === e.app)!
+            const items = e.fields.map(id => DATA.find(d => d.id === id)!).filter(Boolean)
+            const isOpen = open === e.id
+            return (
+              <div key={e.id} className={e.flagged ? 'flag' : ''}>
+                <div className="event" onClick={() => setOpen(isOpen ? null : e.id)}>
+                  <div className="time">{fmtTime(e.at)}<br /><span style={{ opacity: .7 }}>{fmtDate(e.at)}</span></div>
+                  <AgentBadge agent={e.agent} />
+                  <div className="row grow">
+                    <AppAvatar app={app} size="sm" />
+                    <div className="grow">
+                      <div className="trunc" style={{ fontWeight: 500 }}>{app.name} <span className="muted" style={{ fontWeight: 400 }}>· {e.session}</span></div>
+                      <div className="ctx trunc">{e.context}</div>
+                    </div>
+                  </div>
+                  <div className="chips" style={{ gap: 4 }}>
+                    {items.slice(0, 2).map(d => <span key={d.id} className={`tag ${d.category === 'secrets' ? 'red' : ''}`} style={{ height: 22, fontSize: 11.5 }}>{d.label}</span>)}
+                    {items.length > 2 && <span className="tag" style={{ height: 22, fontSize: 11.5 }}>+{items.length - 2}</span>}
+                  </div>
+                  <div className="between"><DecisionBadge d={e.decision} /><Icon name="chevronDown" size={14} className="muted" style={{ transform: isOpen ? 'rotate(180deg)' : undefined, transition: 'transform .2s' }} /></div>
+                </div>
+                {isOpen && (
+                  <div className="event-detail">
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, paddingTop: 16 }}>
+                      <div>
+                        <div className="eyebrow" style={{ marginBottom: 8 }}>Fields in payload</div>
+                        <div className="card">
+                          {items.map(d => (
+                            <div className="between" key={d.id} style={{ padding: '8px 14px', borderTop: '1px solid var(--line)', fontSize: 13.5 }}>
+                              <span className="row" style={{ gap: 8 }}><span style={{ fontWeight: 500 }}>{d.label}</span><span className="mono muted">{d.value}</span></span>
+                              <CategoryTag cat={d.category} />
+                            </div>
+                          ))}
+                        </div>
+                        <div style={{ marginTop: 14 }}>
+                          <div className="eyebrow" style={{ marginBottom: 6 }}>Decision</div>
+                          <div style={{ fontSize: 14 }}><DecisionBadge d={e.decision} />{e.ruleId && <span className="muted"> · rule <span className="mono">{e.ruleId}</span></span>}</div>
+                          {e.reason && <div className="sub" style={{ fontSize: 13.5, marginTop: 4 }}>{e.reason}</div>}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="eyebrow" style={{ marginBottom: 8 }}>Raw request from the plugin</div>
+                        <pre className="code" style={{ borderRadius: 12, padding: '14px 16px', fontSize: 12 }}>{JSON.stringify({
+                          id: e.id, agent: e.agent, session: e.session, app: app.domain, context: e.context,
+                          fields: e.fields, decision: e.decision, rule: e.ruleId ?? null, flagged: !!e.flagged, at: e.at,
+                        }, null, 2)}</pre>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/Alerts.tsx
+++ b/frontend/src/pages/Alerts.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Icon } from '../components/Icon'
+import { AgentBadge } from '../components/ui'
+import { BRAND, DATA } from '../data/mock'
+import { fmtDateTime, timeAgo } from '../lib/format'
+import { useStore } from '../store/store'
+
+export default function Alerts() {
+  const { alerts, events, apps, dispatch } = useStore()
+  const [view, setView] = useState<'open' | 'resolved' | 'all'>('open')
+  const shown = alerts.filter(a => view === 'all' || (view === 'open' ? !a.resolved : a.resolved))
+  const open = alerts.filter(a => !a.resolved)
+
+  return (
+    <>
+      <div className="page-head">
+        <div>
+          <h1 className="h-page">Alerts</h1>
+          <p>{BRAND} raises an alert when a request looks wrong: a secret in a payload, an unverified destination, or an app asking beyond its declared scopes. {open.length} open.</p>
+        </div>
+        <div className="seg">
+          {(['open', 'resolved', 'all'] as const).map(v => <button key={v} className={view === v ? 'on' : ''} onClick={() => setView(v)}>{v[0].toUpperCase() + v.slice(1)}</button>)}
+        </div>
+      </div>
+
+      <div className="stack" style={{ gap: 14 }}>
+        {shown.length === 0 && <div className="card"><div className="empty">Nothing here. Your agents behaved.</div></div>}
+        {shown.map(a => {
+          const ev = events.find(e => e.id === a.eventId)
+          const app = ev && apps.find(x => x.id === ev.app)
+          return (
+            <div className={`alert-card ${a.severity} ${a.resolved ? 'resolved' : ''}`} key={a.id}>
+              <span className={`sev ${a.severity}`} style={a.resolved ? { animation: 'none' } : undefined}><Icon name={a.severity === 'info' ? 'info' : 'alert'} size={18} stroke={2.2} /></span>
+              <div>
+                <div className="row" style={{ gap: 8, fontSize: 12, marginBottom: 6 }}>
+                  <span className={`tag ${a.severity === 'critical' ? 'red' : a.severity === 'warning' ? 'amber' : 'blue'}`}>{a.severity}</span>
+                  <span className="muted">{fmtDateTime(a.at)} · {timeAgo(a.at)}</span>
+                </div>
+                <div style={{ fontWeight: 600, fontSize: 16, letterSpacing: '-0.015em', lineHeight: 1.3 }}>{a.title}</div>
+                <p className="sub" style={{ marginTop: 6, fontSize: 14, maxWidth: '70ch' }}>{a.body}</p>
+                {ev && app && (
+                  <div className="row" style={{ marginTop: 12, gap: 10, fontSize: 13 }}>
+                    <AgentBadge agent={ev.agent} />
+                    <span className="muted">→ {app.domain}</span>
+                    <span className="chips" style={{ gap: 4 }}>
+                      {ev.fields.map(id => DATA.find(d => d.id === id)).filter(Boolean).map(d => (
+                        <span key={d!.id} className={`tag ${d!.category === 'secrets' ? 'red' : 'outline'}`} style={{ height: 22, fontSize: 11.5 }}>{d!.label}</span>
+                      ))}
+                    </span>
+                    <Link to="/app/activity" className="row muted" style={{ gap: 4, marginLeft: 'auto' }}>Open in activity <Icon name="arrowUpRight" size={13} /></Link>
+                  </div>
+                )}
+                {a.severity === 'critical' && !a.resolved && (
+                  <div className="row" style={{ marginTop: 14, gap: 8 }}>
+                    <button className="btn danger sm"><Icon name="key" size={13} />Rotate the key</button>
+                    <button className="btn ghost sm" onClick={() => dispatch({ type: 'toggleApp', id: ev?.app ?? '' })}>Block {app?.name ?? 'app'} for good</button>
+                  </div>
+                )}
+              </div>
+              <div>
+                {a.resolved
+                  ? <span className="tag green"><Icon name="check" size={11} stroke={2.5} />Resolved</span>
+                  : <button className="btn soft sm" onClick={() => dispatch({ type: 'resolveAlert', id: a.id })}><Icon name="check" size={13} />Resolve</button>}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/Apps.tsx
+++ b/frontend/src/pages/Apps.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { Icon } from '../components/Icon'
+import { AppAvatar, CAT_ICON, Toggle, TrustTag } from '../components/ui'
+import { APP_CATEGORIES } from '../data/mock'
+import { DATA_CATEGORIES, type AppCategoryId } from '../data/types'
+import { timeAgo } from '../lib/format'
+import { matchRule } from '../store/engine'
+import { useStore } from '../store/store'
+
+export default function Apps() {
+  const { apps, rules, dispatch } = useStore()
+  const [cat, setCat] = useState<AppCategoryId | null>(null)
+  const [onlyConnected, setOnlyConnected] = useState(false)
+  const shown = apps.filter(a => (!cat || a.category === cat) && (!onlyConnected || a.connected))
+
+  return (
+    <>
+      <div className="page-head">
+        <div>
+          <h1 className="h-page">Applications</h1>
+          <p>Every app declares the scopes it needs. Your rules decide what each one actually receives, and the agent can explain the outcome in one paragraph.</p>
+        </div>
+        <label className="row" style={{ gap: 10, fontSize: 14, fontWeight: 500 }}>
+          Connected only <Toggle on={onlyConnected} onChange={() => setOnlyConnected(v => !v)} />
+        </label>
+      </div>
+
+      <div className="cat-grid">
+        {APP_CATEGORIES.map(c => {
+          const n = apps.filter(a => a.category === c.id).length
+          const on = apps.filter(a => a.category === c.id && a.connected).length
+          return (
+            <button key={c.id} className={`cat ${cat === c.id ? 'on' : ''}`} onClick={() => setCat(cat === c.id ? null : c.id)}>
+              <span className="ic"><Icon name={CAT_ICON[c.id]} size={16} /></span>
+              <span>
+                <div className="n">{c.label}</div>
+                <div className="c">{on} connected · {n} apps</div>
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="between">
+        <div className="h-sec">{cat ? APP_CATEGORIES.find(c => c.id === cat)!.label : 'All apps'} <span className="muted" style={{ fontWeight: 400 }}>· {shown.length}</span></div>
+        <div className="row muted" style={{ fontSize: 12.5, gap: 14 }}>
+          <span className="row" style={{ gap: 6 }}><i className="scope allow" style={{ width: 10, height: 10, padding: 0 }} />Shared</span>
+          <span className="row" style={{ gap: 6 }}><i className="scope ask" style={{ width: 10, height: 10, padding: 0 }} />Ask me</span>
+          <span className="row" style={{ gap: 6 }}><i className="scope deny" style={{ width: 10, height: 10, padding: 0 }} />Never</span>
+        </div>
+      </div>
+
+      <div className="app-grid">
+        {shown.map(app => (
+          <div className="app-card" key={app.id} style={app.trust === 'unknown' ? { borderColor: 'rgba(229,72,77,.35)' } : undefined}>
+            <div className="row">
+              <AppAvatar app={app} />
+              <div className="grow">
+                <div className="row" style={{ gap: 8 }}><span style={{ fontWeight: 600 }}>{app.name}</span><TrustTag trust={app.trust} /></div>
+                <div className="muted" style={{ fontSize: 12.5 }}>{app.domain} · {APP_CATEGORIES.find(c => c.id === app.category)!.label}</div>
+              </div>
+              <Toggle on={app.connected} onChange={() => dispatch({ type: 'toggleApp', id: app.id })} green />
+            </div>
+            <div className="desc">{app.blurb}</div>
+            <div className="scopes">
+              {app.scopes.length === 0 && <span className="muted" style={{ fontSize: 13 }}>No declared scopes. Any request is flagged.</span>}
+              {app.scopes.map(s => {
+                const r = matchRule(s, app, null, rules)
+                const eff = r?.effect ?? 'ask'
+                return <button key={s} className={`scope ${eff}`} onClick={() => dispatch({ type: 'drawer', id: app.id })} title={r ? `Rule ${r.id}` : 'No rule yet — you will be asked'}>{DATA_CATEGORIES[s].label}</button>
+              })}
+            </div>
+            <div className="between" style={{ marginTop: 'auto', paddingTop: 4 }}>
+              <span className="muted" style={{ fontSize: 12.5 }}>{app.lastAccess ? `Last access ${timeAgo(app.lastAccess)} · ${app.requests} requests` : 'Never accessed'}</span>
+              <button className="btn soft sm" onClick={() => dispatch({ type: 'drawer', id: app.id })}><Icon name="sparkle" size={13} />Explain</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/Data.tsx
+++ b/frontend/src/pages/Data.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState } from 'react'
+import { Icon } from '../components/Icon'
+import { CategoryTag, Sens, SourceBadge } from '../components/ui'
+import { BRAND, DATA, SOURCES } from '../data/mock'
+import { DATA_CATEGORIES, type DataCategory, type SourceKind } from '../data/types'
+import { fmtDate, timeAgo } from '../lib/format'
+
+type KindFilter = 'all' | SourceKind
+const KINDS: { id: KindFilter; label: string }[] = [
+  { id: 'all', label: 'All' }, { id: 'website', label: 'Websites' }, { id: 'codex', label: 'Codex' }, { id: 'claude-code', label: 'Claude Code' }, { id: 'browser', label: 'Browser' },
+]
+
+export default function Data() {
+  const [kind, setKind] = useState<KindFilter>('all')
+  const [cat, setCat] = useState<DataCategory | null>(null)
+  const [q, setQ] = useState('')
+  const [revealed, setRevealed] = useState<Record<string, boolean>>({})
+
+  const rows = useMemo(() => DATA.filter(d => {
+    const src = SOURCES.find(s => s.id === d.source)!
+    if (kind !== 'all' && src.kind !== kind) return false
+    if (cat && d.category !== cat) return false
+    if (q && !`${d.label} ${d.value} ${src.name}`.toLowerCase().includes(q.toLowerCase())) return false
+    return true
+  }), [kind, cat, q])
+
+  const counts = (Object.keys(DATA_CATEGORIES) as DataCategory[]).map(c => ({ c, n: DATA.filter(d => d.category === c).length }))
+  const agentItems = DATA.filter(d => ['codex', 'claude-code'].includes(SOURCES.find(s => s.id === d.source)!.kind))
+
+  return (
+    <>
+      <div className="page-head">
+        <div>
+          <h1 className="h-page">My data</h1>
+          <p>Everything {BRAND} found about you across websites and agent sessions. Values are masked at rest and only revealed here, on your device.</p>
+        </div>
+        <div className="row" style={{ gap: 8 }}>
+          <button className="btn ghost"><Icon name="download" size={15} />Export</button>
+          <button className="btn ghost"><Icon name="trash" size={15} />Request deletion</button>
+        </div>
+      </div>
+
+      <div className="three">
+        <div className="stack" style={{ gap: 20 }}>
+          <div className="card">
+            <div style={{ padding: '14px 16px 6px' }} className="eyebrow">Categories</div>
+            <div className="list">
+              <button className={`item clickable ${cat === null ? '' : ''}`} onClick={() => setCat(null)} style={{ background: cat === null ? 'var(--bg-2)' : undefined }}>
+                <span className="grow" style={{ textAlign: 'left', fontWeight: 500 }}>All data</span><span className="mono muted">{DATA.length}</span>
+              </button>
+              {counts.map(({ c, n }) => (
+                <button className="item clickable" key={c} onClick={() => setCat(cat === c ? null : c)} style={{ background: cat === c ? 'var(--bg-2)' : undefined }}>
+                  <span className="grow" style={{ textAlign: 'left' }}>
+                    <div style={{ fontWeight: 500 }}>{DATA_CATEGORIES[c].label}</div>
+                    <div className="s">{DATA_CATEGORIES[c].hint}</div>
+                  </span>
+                  <span className="mono muted">{n}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="card">
+            <div style={{ padding: '14px 16px 6px' }} className="eyebrow">Sources</div>
+            <div className="list">
+              {SOURCES.map(s => (
+                <div className="item" key={s.id} style={{ padding: '10px 16px' }}>
+                  <div className="grow"><SourceBadge source={s} /></div>
+                  <span className="mono muted" style={{ fontSize: 11.5 }}>{timeAgo(s.lastSync)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="stack" style={{ gap: 20 }}>
+          <div className="between">
+            <div className="seg">
+              {KINDS.map(k => <button key={k.id} className={kind === k.id ? 'on' : ''} onClick={() => setKind(k.id)}>{k.label}</button>)}
+            </div>
+            <div className="field" style={{ width: 280, height: 36 }}>
+              <Icon name="search" size={15} className="muted" />
+              <input placeholder="Filter fields…" value={q} onChange={e => setQ(e.target.value)} />
+            </div>
+          </div>
+          <div className="card" style={{ overflow: 'auto' }}>
+            <table className="tbl">
+              <thead><tr><th>Field</th><th>Category</th><th>Source</th><th>Sensitivity</th><th>Collected</th></tr></thead>
+              <tbody>
+                {rows.length === 0 && <tr><td colSpan={5}><div className="empty">Nothing matches.</div></td></tr>}
+                {rows.map(d => {
+                  const src = SOURCES.find(s => s.id === d.source)!
+                  const shown = revealed[d.id]
+                  return (
+                    <tr key={d.id}>
+                      <td>
+                        <div style={{ fontWeight: 500 }}>{d.label}</div>
+                        <span className="row" style={{ gap: 8, marginTop: 2 }}>
+                          <span className="mono" style={{ fontSize: 12.5, color: shown ? 'var(--ink)' : 'var(--ink-3)' }}>{shown ? d.value.replace(/•/g, '4') : d.value}</span>
+                          <button className="muted" onClick={() => setRevealed(r => ({ ...r, [d.id]: !r[d.id] }))} aria-label="Reveal"><Icon name={shown ? 'eyeOff' : 'eye'} size={13} /></button>
+                        </span>
+                      </td>
+                      <td><CategoryTag cat={d.category} /></td>
+                      <td><SourceBadge source={src} /></td>
+                      <td><Sens level={d.sensitivity} /></td>
+                      <td className="mono muted">{fmtDate(d.collectedAt)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="card pad" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24 }}>
+            <div>
+              <div className="row" style={{ gap: 8 }}><Icon name="terminal" size={16} /><div className="h-sec">From your agent sessions</div></div>
+              <p className="sub" style={{ marginTop: 8, fontSize: 14 }}>
+                The plugin reads what Codex and Claude Code saw: repository names, commit identities, values in <span className="mono">.env</span> files, travel dates you typed in a prompt.
+                Secrets are stored as fingerprints only, never as plaintext.
+              </p>
+            </div>
+            <div className="list" style={{ border: '1px solid var(--line)', borderRadius: 12 }}>
+              {agentItems.map(d => (
+                <div className="item" key={d.id} style={{ padding: '9px 14px' }}>
+                  <span className="mono grow">{d.label}</span>
+                  <Sens level={d.sensitivity} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { Icon } from '../components/Icon'
+import { BrandMark } from '../components/Shell'
+import { BRAND, SLUG } from '../data/mock'
+
+export default function Landing() {
+  const [scrolled, setScrolled] = useState(false)
+  useEffect(() => {
+    const on = () => setScrolled(window.scrollY > 8)
+    on(); window.addEventListener('scroll', on, { passive: true })
+    return () => window.removeEventListener('scroll', on)
+  }, [])
+
+  return (
+    <div>
+      <header className={`mk-nav ${scrolled ? 'scrolled' : ''}`}>
+        <Link to="/" className="brand"><BrandMark />{BRAND}</Link>
+        <nav>
+          <ScrollLink to="how">How it works</ScrollLink>
+          <ScrollLink to="features">Product</ScrollLink>
+          <ScrollLink to="developers">Developers</ScrollLink>
+          <ScrollLink to="hackathon">Hackathon</ScrollLink>
+        </nav>
+        <div className="row" style={{ gap: 8 }}>
+          <Link to="/app" className="btn ghost" style={{ height: 36 }}>Log in</Link>
+          <Link to="/app" className="btn" style={{ height: 36 }}>Open dashboard</Link>
+        </div>
+      </header>
+
+      <section className="wrap hero">
+        <div className="hero-grid">
+          <div>
+            <div className="rise d1"><span className="tag outline" style={{ height: 28, padding: '0 12px' }}><span className="dot" style={{ background: 'var(--green)' }} />OpenAI AI Privacy Hackathon · Station F, Paris · 3 Sept 2026</span></div>
+            <h1 className="rise d2" style={{ marginTop: 24 }}>The OAuth layer for your data and AI agents.</h1>
+            <p className="lead rise d3">
+              {BRAND} sits between your personal data and every agent or app that asks for it.
+              You write the rules in plain language. Agents request consent. Every share is logged,
+              explained, and stopped when it should never happen.
+            </p>
+            <div className="hero-cta rise d4">
+              <Link to="/app" className="btn lg">Open the dashboard <Icon name="arrowRight" size={16} /></Link>
+              <ScrollLink to="developers" className="btn ghost lg"><Icon name="terminal" size={16} />Install the plugin</ScrollLink>
+            </div>
+            <div className="rise d5 mono muted" style={{ marginTop: 40, display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+              <span>26 data points found</span><span>11 apps connected</span><span>9 rules</span><span style={{ color: 'var(--red)' }}>1 leak blocked today</span>
+            </div>
+          </div>
+          <div className="rise d3"><FlowVisual /></div>
+        </div>
+      </section>
+
+      <section className="wrap section" id="how">
+        <div className="eyebrow">How it works</div>
+        <h2 style={{ marginTop: 14 }}>Three moves between your data and the world.</h2>
+        <div className="steps">
+          <div className="step">
+            <div className="num">01 — See</div>
+            <h3>Everything the internet and your agents know about you.</h3>
+            <p>{BRAND} pulls what websites hold and what Codex or Claude Code sessions have touched: addresses, cards, repos, even the API key sitting in your env file.</p>
+          </div>
+          <div className="step">
+            <div className="num">02 — Decide</div>
+            <h3>Rules in plain language, or an agent that explains.</h3>
+            <p>"Never share my location with streaming apps." Or ask the {BRAND} agent what Booking.com would receive before you connect it.</p>
+          </div>
+          <div className="step" style={{ background: 'var(--ink)', color: '#fff' }}>
+            <div className="num" style={{ color: '#8e8ea0' }}>03 — Enforce</div>
+            <h3>The plugin asks, logs, and pulls the alarm.</h3>
+            <p style={{ color: '#b6b6c4' }}>Installed in Codex, Claude Code or ChatGPT agents, it intercepts every outbound share, prompts you when a rule says so, and blocks secrets before they leave your machine.</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="wrap section" id="features" style={{ paddingTop: 0 }}>
+        <div className="eyebrow">Product</div>
+        <h2 style={{ marginTop: 14 }}>One dashboard. Four things you could never see before.</h2>
+        <div className="feat-grid">
+          <div className="feat">
+            <div>
+              <h3>Your data, with its provenance</h3>
+              <p>Every field carries where it came from, how sensitive it is, and when it was collected. Websites and agent sessions side by side.</p>
+            </div>
+            <div className="preview">
+              {[
+                ['Home address', '12 rue Oberkampf, Paris', 'Amazon', 'high'],
+                ['Upcoming trip', 'Lisbon · 12–19 Oct', 'Codex · travel-planner', 'medium'],
+                ['OPENAI_API_KEY', 'sk-proj-••••••••Q4', 'Codex · travel-planner', 'critical'],
+              ].map(r => (
+                <div className="between" key={r[0]} style={{ padding: '8px 0', borderTop: '1px solid var(--line)', fontSize: 13 }}>
+                  <div><div style={{ fontWeight: 500 }}>{r[0]}</div><div className="mono muted" style={{ fontSize: 12 }}>{r[1]}</div></div>
+                  <div className="row" style={{ gap: 10 }}><span className="tag outline">{r[2]}</span><span className={`sens ${r[3]}`}><i /></span></div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="feat">
+            <div>
+              <h3>Apps by category, with declared scopes</h3>
+              <p>Travel, streaming, finance, developer tools. Each app declares what it needs, and {BRAND} flags anything it asks for beyond that.</p>
+            </div>
+            <div className="preview">
+              <div className="chips" style={{ marginBottom: 12 }}>
+                {['Travel · 4', 'Streaming · 3', 'Finance · 2', 'Developer · 3'].map(c => <span className="chip" key={c}>{c}</span>)}
+              </div>
+              <div className="between" style={{ fontSize: 13 }}>
+                <div className="row"><span className="avatar sm" style={{ background: '#003580' }}>B</span><div><div style={{ fontWeight: 500 }}>Booking.com</div><div className="muted" style={{ fontSize: 12 }}>booking.com</div></div></div>
+                <div className="scopes"><span className="scope allow">Identity</span><span className="scope allow">Contact</span><span className="scope ask">Financial</span></div>
+              </div>
+            </div>
+          </div>
+          <div className="feat">
+            <div>
+              <h3>Rules written the way you think</h3>
+              <p>Type a sentence. {BRAND} turns it into a structured policy with an effect, a data scope and a target, and applies it to the next request.</p>
+            </div>
+            <div className="preview">
+              <div style={{ fontSize: 16, letterSpacing: '-0.01em' }}>"Ask me before any Codex session shares where I am."</div>
+              <div className="row" style={{ marginTop: 12, gap: 8 }}>
+                <span className="effect ask">Ask</span>
+                <span className="rule-sentence" style={{ fontSize: 13.5 }}>Ask before sharing <b>location</b> with <b>Codex sessions</b></span>
+              </div>
+            </div>
+          </div>
+          <div className="feat" style={{ borderColor: 'rgba(229,72,77,.35)' }}>
+            <div>
+              <h3>Live consent, a full log, and a loud alarm</h3>
+              <p>Requests from your agents show up as consent prompts. Everything lands in the activity log. A leaked secret triggers a takeover you cannot miss.</p>
+            </div>
+            <div className="preview" style={{ background: '#fff' }}>
+              <div className="row" style={{ gap: 10 }}>
+                <span className="sev critical" style={{ width: 32, height: 32, borderRadius: 9 }}><Icon name="alert" size={16} stroke={2.2} /></span>
+                <div style={{ fontSize: 13.5 }}><div style={{ fontWeight: 600 }}>Blocked: Codex tried to send OPENAI_API_KEY to paste-share.io</div><div className="muted" style={{ fontSize: 12 }}>Stopped before leaving your machine · 2 h ago</div></div>
+              </div>
+              <div className="divider" style={{ margin: '12px 0' }} />
+              <div className="between" style={{ fontSize: 13 }}><span className="agent"><span className="ic claude">CC</span>Claude Code → GitHub</span><span className="decision allowed"><i />Allowed · r-07</span></div>
+              <div className="between" style={{ fontSize: 13, marginTop: 8 }}><span className="agent"><span className="ic chatgpt">GP</span>ChatGPT → Netflix</span><span className="decision denied"><i />Denied · r-03</span></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="wrap" style={{ padding: '0 32px 96px' }}>
+        <div className="eyebrow">Works with your agents</div>
+        <div className="logos">
+          <span><span className="agent"><span className="ic codex">CX</span></span>Codex</span>
+          <span><span className="agent"><span className="ic claude">CC</span></span>Claude Code</span>
+          <span><span className="agent"><span className="ic chatgpt">GP</span></span>ChatGPT agents</span>
+          <span><span className="agent"><span className="ic cursor">CU</span></span>Cursor</span>
+          <span className="muted" style={{ fontWeight: 500, fontSize: 14 }}>+ any MCP-compatible agent</span>
+        </div>
+      </section>
+
+      <section className="wrap section" id="developers" style={{ paddingTop: 0 }}>
+        <div className="hero-grid" style={{ alignItems: 'start' }}>
+          <div>
+            <div className="eyebrow">Developers</div>
+            <h2 style={{ marginTop: 14 }}>One plugin. One endpoint. Consent before bytes leave.</h2>
+            <p className="lead">The plugin hooks the agent's outbound tool calls. Before any payload reaches a third party it asks {BRAND} for a decision, resolved locally against your rules in under a millisecond.</p>
+            <div className="row" style={{ marginTop: 28, gap: 10 }}>
+              <Link to="/app/activity" className="btn ghost">See the request log <Icon name="arrowUpRight" size={15} /></Link>
+            </div>
+          </div>
+          <pre className="code">{`$ codex plugin add @${SLUG}/consent
+`}<span className="g">✓</span>{` plugin installed · policy synced (`}<span className="y">9 rules</span>{`)
+
+`}<span className="c"># sent by the plugin before any data leaves your machine</span>{`
+POST https://api.${SLUG}.dev/v1/consent
+{
+  "agent":   "codex",
+  "session": "travel-planner",
+  "app":     "booking.com",
+  "fields":  ["full_name", "email", "travel_dates"]
+}
+
+`}<span className="c">← 200</span>{`
+{
+  "decision": `}<span className="y">"ask"</span>{`,
+  "rule":     "r-09",
+  "prompt":   `}<span className="p">"https://app.${SLUG}.dev/consent/7f3a"</span>{`
+}`}</pre>
+        </div>
+      </section>
+
+      <section className="wrap" id="hackathon" style={{ paddingBottom: 96 }}>
+        <div className="card" style={{ padding: 48, borderRadius: 28, background: 'var(--bg-2)', border: 0, display: 'grid', gridTemplateColumns: '1fr auto', gap: 32, alignItems: 'center' }}>
+          <div>
+            <div className="eyebrow">OpenAI AI Privacy Hackathon</div>
+            <h2 style={{ marginTop: 12, fontSize: 36 }}>Built in a day at Station F, so you can see the demo in two minutes.</h2>
+            <p className="lead" style={{ marginTop: 12 }}>Open the dashboard, hit "Simulate agent request" and watch consent prompts, logs and a blocked leak happen live on mock data.</p>
+          </div>
+          <Link to="/app" className="btn lg">Try the live demo <Icon name="arrowRight" size={16} /></Link>
+        </div>
+      </section>
+
+      <footer className="wrap footer">
+        <span className="row"><BrandMark size={22} /> {BRAND} — the OAuth layer for your data and AI agents.</span>
+        <span>Mock data · No real accounts were harmed · 2026</span>
+      </footer>
+    </div>
+  )
+}
+
+function ScrollLink({ to, className, children }: { to: string; className?: string; children: ReactNode }) {
+  return (
+    <a href={`#${to}`} className={className} onClick={e => { e.preventDefault(); document.getElementById(to)?.scrollIntoView({ behavior: 'smooth' }) }}>
+      {children}
+    </a>
+  )
+}
+
+function FlowVisual() {
+  const left = [
+    { y: 70, label: 'Email', src: 'google' },
+    { y: 132, label: 'Home address', src: 'amazon' },
+    { y: 194, label: 'Upcoming trip', src: 'codex' },
+    { y: 256, label: 'OPENAI_API_KEY', src: 'codex · env', bad: true },
+    { y: 318, label: 'Watch history', src: 'netflix' },
+  ]
+  const right = [
+    { y: 100, label: 'Booking.com' },
+    { y: 165, label: 'GitHub' },
+    { y: 230, label: 'Netflix' },
+    { y: 300, label: 'paste-share.io', bad: true },
+  ]
+  const GX1 = 212, GX2 = 348, GY = 210
+  const inPath = (y: number) => `M156,${y} C 185,${y} 180,${GY} ${GX1},${GY}`
+  const outPath = (y: number) => `M${GX2},${GY} C 378,${GY} 372,${y} 404,${y}`
+  return (
+    <svg className="flow" viewBox="0 0 560 420" width="100%" style={{ height: 'auto', display: 'block' }} aria-label={`Data flowing through the ${BRAND} policy gate`}>
+      <defs>
+        <filter id="sh" x="-20%" y="-20%" width="140%" height="160%"><feDropShadow dx="0" dy="10" stdDeviation="12" floodColor="#0d0d0d" floodOpacity=".25" /></filter>
+      </defs>
+      <rect width="560" height="420" rx="28" fill="#f7f7f8" />
+      <text x="16" y="36" fontFamily="var(--mono)" fontSize="11" fill="#8e8ea0">YOUR DATA</text>
+      <text x="544" y="36" fontFamily="var(--mono)" fontSize="11" fill="#8e8ea0" textAnchor="end">APPS &amp; AGENTS</text>
+
+      {left.map(n => <path key={n.y} d={inPath(n.y)} stroke="#d9d9e3" strokeWidth="1.25" fill="none" />)}
+      {right.map(n => <path key={n.y} d={outPath(n.y)} stroke={n.bad ? '#f0c4c6' : '#d9d9e3'} strokeWidth="1.25" fill="none" strokeDasharray={n.bad ? '3 4' : undefined} />)}
+
+      {left.map(n => (
+        <g key={n.label}>
+          <rect x="16" y={n.y - 17} width="140" height="34" rx="17" fill="#fff" stroke="#ececf1" />
+          <circle cx="34" cy={n.y} r="4" fill={n.bad ? '#e5484d' : '#0d0d0d'} />
+          <text x="46" y={n.y - 2} fontFamily="var(--font)" fontSize="11.5" fontWeight="600" fill="#0d0d0d">{n.label}</text>
+          <text x="46" y={n.y + 10} fontFamily="var(--mono)" fontSize="9.5" fill="#8e8ea0">{n.src}</text>
+        </g>
+      ))}
+      {right.map(n => (
+        <g key={n.label}>
+          <rect x="404" y={n.y - 17} width="140" height="34" rx="17" fill="#fff" stroke={n.bad ? '#f0c4c6' : '#ececf1'} />
+          <text x="422" y={n.y + 4} fontFamily="var(--font)" fontSize="12" fontWeight="600" fill={n.bad ? '#b5232a' : '#0d0d0d'}>{n.label}</text>
+        </g>
+      ))}
+
+      <g filter="url(#sh)">
+        <rect x={GX1} y="140" width={GX2 - GX1} height="140" rx="18" fill="#0d0d0d" />
+      </g>
+      <g>
+        <circle cx={GX1 + 22} cy="162" r="7" stroke="#fff" strokeWidth="2" fill="none" />
+        <circle cx={GX1 + 22} cy="162" r="2.4" fill="#10a37f" />
+        <text x={GX1 + 36} y="166" fontFamily="var(--font)" fontSize="13" fontWeight="600" fill="#fff">{BRAND} gate</text>
+        <text x={GX1 + 14} y="186" fontFamily="var(--mono)" fontSize="9" fill="#a5a5b5">policy · 9 rules · 0.4ms</text>
+        <rect x={GX1 + 12} y="198" width={GX2 - GX1 - 24} height="30" rx="7" fill="rgba(255,255,255,.08)" />
+        <text x={GX1 + 20} y="211" fontFamily="var(--mono)" fontSize="9" fill="#3fd0a8">r-02 allow id → travel</text>
+        <text x={GX1 + 20} y="222" fontFamily="var(--mono)" fontSize="9" fill="#ff8a8e">r-01 block secrets → *</text>
+        <rect x={GX1 + 12} y="236" width={GX2 - GX1 - 24} height="30" rx="7" fill="rgba(255,255,255,.08)" />
+        <text x={GX1 + 20} y="249" fontFamily="var(--mono)" fontSize="9" fill="#e8e8ee">3 shared · 1 asked</text>
+        <text x={GX1 + 20} y="260" fontFamily="var(--mono)" fontSize="9" fill="#ff8a8e">1 blocked</text>
+      </g>
+
+      {/* packets in */}
+      {left.map((n, i) => (
+        <circle key={`p${n.y}`} r="4.5" fill={n.bad ? '#e5484d' : '#0d0d0d'}>
+          <animateMotion dur="2.6s" begin={`${i * 0.55}s`} repeatCount="indefinite" path={inPath(n.y)} keyPoints="0;1" keyTimes="0;1" calcMode="linear" />
+          <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;.08;.9;1" dur="2.6s" begin={`${i * 0.55}s`} repeatCount="indefinite" />
+        </circle>
+      ))}
+      {/* packets out */}
+      {right.filter(n => !n.bad).map((n, i) => (
+        <circle key={`q${n.y}`} r="4.5" fill="#10a37f">
+          <animateMotion dur="2.6s" begin={`${1.3 + i * 0.7}s`} repeatCount="indefinite" path={outPath(n.y)} />
+          <animate attributeName="opacity" values="0;1;1;0" keyTimes="0;.08;.9;1" dur="2.6s" begin={`${1.3 + i * 0.7}s`} repeatCount="indefinite" />
+        </circle>
+      ))}
+      {/* blocked marker */}
+      <g>
+        <circle cx={GX2 + 14} cy="300" r="9" fill="#fdecec" stroke="#e5484d" strokeWidth="1.5">
+          <animate attributeName="r" values="9;11;9" dur="1.6s" repeatCount="indefinite" />
+        </circle>
+        <path d={`M${GX2 + 10.5},296.5 l7,7 M${GX2 + 17.5},296.5 l-7,7`} stroke="#e5484d" strokeWidth="1.8" strokeLinecap="round" />
+      </g>
+    </svg>
+  )
+}

--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -1,0 +1,106 @@
+import { Link } from 'react-router-dom'
+import { Icon } from '../components/Icon'
+import { AgentBadge, AppAvatar, DecisionBadge, Stat } from '../components/ui'
+import { BRAND, DATA, SOURCES, USER } from '../data/mock'
+import { AGENTS, type AgentId } from '../data/types'
+import { timeAgo } from '../lib/format'
+import { useStore } from '../store/store'
+
+export default function Overview() {
+  const { apps, rules, events, alerts, unresolved, simulate } = useStore()
+  const connected = apps.filter(a => a.connected).length
+  const stopped = events.filter(e => e.decision === 'denied' || e.decision === 'blocked').length
+  const fromAgents = DATA.filter(d => SOURCES.find(s => s.id === d.source)?.kind !== 'website' && SOURCES.find(s => s.id === d.source)?.kind !== 'browser').length
+  const byAgent = (Object.keys(AGENTS) as AgentId[]).map(a => ({ a, n: events.filter(e => e.agent === a).length })).sort((x, y) => y.n - x.n)
+  const max = Math.max(...byAgent.map(b => b.n), 1)
+  const hour = new Date().getHours()
+  const greet = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening'
+
+  return (
+    <>
+      <div className="page-head">
+        <div>
+          <h1 className="h-page">{greet}, {USER.name.split(' ')[0]}.</h1>
+          <p>Here is what agents and apps did with your data. Last plugin sync {timeAgo(SOURCES.find(s => s.id === 'chrome')!.lastSync)}.</p>
+        </div>
+        <button className="btn ghost" onClick={simulate}><Icon name="zap" size={15} />Simulate a request</button>
+      </div>
+
+      <div className="stats">
+        <Stat label="Data points known" value={DATA.length} delta={`${fromAgents} came from agent sessions`} />
+        <Stat label="Connected apps" value={connected} delta={`of ${apps.length} in the catalogue`} />
+        <Stat label="Active rules" value={rules.filter(r => r.enabled).length} delta={`${rules.filter(r => r.createdBy === 'agent').length} suggested by the agent`} />
+        <Stat label="Requests · 7 days" value={events.length} delta={`${stopped} stopped`} tone={stopped ? 'red' : undefined} />
+      </div>
+
+      <div className="two">
+        <div className="card">
+          <div className="between" style={{ padding: '16px 18px', borderBottom: '1px solid var(--line)' }}>
+            <div className="h-sec">Recent activity</div>
+            <Link to="/app/activity" className="row muted" style={{ fontSize: 13, gap: 4 }}>All activity <Icon name="chevronRight" size={14} /></Link>
+          </div>
+          <div className="list">
+            {events.slice(0, 7).map(e => {
+              const app = apps.find(a => a.id === e.app)!
+              return (
+                <Link to="/app/activity" className={`item clickable ${e.flagged ? 'flag' : ''}`} key={e.id}>
+                  <AgentBadge agent={e.agent} compact />
+                  <AppAvatar app={app} size="sm" />
+                  <div className="grow">
+                    <div className="t trunc">{AGENTS[e.agent].label} → {app.name}</div>
+                    <div className="s trunc">{e.context} · {e.fields.length} field{e.fields.length > 1 ? 's' : ''}</div>
+                  </div>
+                  <DecisionBadge d={e.decision} />
+                  <span className="mono muted" style={{ width: 72, textAlign: 'right' }}>{timeAgo(e.at)}</span>
+                </Link>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="stack" style={{ gap: 20 }}>
+          <div className="card">
+            <div className="between" style={{ padding: '16px 18px', borderBottom: '1px solid var(--line)' }}>
+              <div className="h-sec">Needs attention</div>
+              <Link to="/app/alerts" className="row muted" style={{ fontSize: 13, gap: 4 }}>{unresolved.length} open <Icon name="chevronRight" size={14} /></Link>
+            </div>
+            <div className="list">
+              {unresolved.length === 0 && <div className="empty">All clear.</div>}
+              {unresolved.slice(0, 3).map(a => (
+                <Link to="/app/alerts" className="item clickable" key={a.id} style={{ alignItems: 'flex-start' }}>
+                  <span className={`sev ${a.severity}`} style={{ width: 30, height: 30, borderRadius: 9, animation: 'none' }}><Icon name={a.severity === 'info' ? 'info' : 'alert'} size={15} stroke={2.2} /></span>
+                  <div className="grow">
+                    <div className="t" style={{ fontSize: 14, lineHeight: 1.35 }}>{a.title}</div>
+                    <div className="s">{timeAgo(a.at)}</div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="card pad">
+            <div className="h-sec" style={{ marginBottom: 14 }}>Who asks the most</div>
+            <div className="stack" style={{ gap: 12 }}>
+              {byAgent.map(b => (
+                <div key={b.a}>
+                  <div className="between" style={{ fontSize: 13.5, marginBottom: 6 }}>
+                    <AgentBadge agent={b.a} />
+                    <span className="mono muted">{b.n} requests</span>
+                  </div>
+                  <div className="bar"><i style={{ width: `${(b.n / max) * 100}%` }} /></div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="card pad" style={{ background: 'var(--ink)', color: '#fff', border: 0 }}>
+            <div className="row" style={{ gap: 8, color: '#a5a5b5', fontSize: 12, fontWeight: 600, letterSpacing: '.04em', textTransform: 'uppercase' }}><Icon name="sparkle" size={13} />{BRAND} agent</div>
+            <p style={{ marginTop: 10, fontSize: 15, lineHeight: 1.5 }}>
+              You have no rule for <b>identity documents</b> yet. Airbnb received your passport number last week under the general travel rule. Want me to require approval for it?
+            </p>
+            <Link to="/app/rules" className="btn" style={{ marginTop: 14, background: '#fff', color: 'var(--ink)', borderColor: '#fff' }}>Review suggestion</Link>
+          </div>
+        </div>
+      </div>
+      <div className="muted" style={{ fontSize: 12.5 }}>{alerts.filter(a => a.resolved).length} alerts resolved this month.</div>
+    </>
+  )
+}

--- a/frontend/src/pages/Rules.tsx
+++ b/frontend/src/pages/Rules.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from 'react'
+import { Icon } from '../components/Icon'
+import { Toggle } from '../components/ui'
+import { BRAND } from '../data/mock'
+import type { Rule } from '../data/types'
+import { fmtDate } from '../lib/format'
+import { dataLabel, parseRule, targetLabel } from '../store/engine'
+import { useStore } from '../store/store'
+
+const SUGGESTIONS = [
+  'Never share my health data with social apps',
+  'Ask me before Codex shares anything financial',
+  'Allow Notion to use my work profile',
+  'Block my home address for shopping apps',
+]
+
+const AGENT_SUGGESTIONS: { text: string; why: string; rule: Omit<Rule, 'id' | 'createdAt' | 'enabled' | 'createdBy'> }[] = [
+  {
+    text: 'Ask before sharing identity documents with any app',
+    why: 'Airbnb received your passport number under the general travel rule on 29 Aug.',
+    rule: { effect: 'ask', data: ['identity'], target: { type: 'category', id: 'travel' }, note: `Suggested by the ${BRAND} agent after a passport share.` },
+  },
+  {
+    text: 'Never share location with social apps',
+    why: 'LinkedIn and Instagram both declare Location, and no rule covers it yet.',
+    rule: { effect: 'deny', data: ['location'], target: { type: 'category', id: 'social' }, note: `Suggested by the ${BRAND} agent.` },
+  },
+]
+
+export default function Rules() {
+  const { rules, dispatch, addRule } = useStore()
+  const [text, setText] = useState('')
+  const parsed = useMemo(() => parseRule(text), [text])
+
+  return (
+    <>
+      <div className="page-head">
+        <div>
+          <h1 className="h-page">Rules</h1>
+          <p>Write what you want in plain language. {BRAND} turns it into a policy that runs locally, before any request leaves your machine. More specific rules win: app over agent over category over everything.</p>
+        </div>
+      </div>
+
+      <div className="composer">
+        <div className="row" style={{ gap: 8, marginBottom: 10 }} >
+          <Icon name="sparkle" size={15} className="muted" />
+          <span className="eyebrow">New rule</span>
+        </div>
+        <textarea
+          value={text}
+          onChange={e => setText(e.target.value)}
+          placeholder="Never share my health data with social apps…"
+          rows={2}
+          onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey && parsed) { e.preventDefault(); addRule(parsed); setText('') } }}
+        />
+        <div className="between" style={{ marginTop: 12, alignItems: 'flex-end', gap: 20 }}>
+          <div className="grow">
+            {parsed ? (
+              <div className="preview-rule row" style={{ gap: 12 }}>
+                <span className={`effect ${parsed.effect}`}>{parsed.effect}</span>
+                <Sentence effect={parsed.effect} data={parsed.data} target={parsed.target} />
+              </div>
+            ) : text.length > 0 ? (
+              <div className="muted" style={{ fontSize: 13.5 }}>Mention what data (address, card, health, repos…) and optionally which app, category or agent.</div>
+            ) : (
+              <div className="chips">
+                {SUGGESTIONS.map(s => <button key={s} className="chip" onClick={() => setText(s)}>{s}</button>)}
+              </div>
+            )}
+          </div>
+          <button className="btn" disabled={!parsed} onClick={() => { if (parsed) { addRule(parsed); setText('') } }}>Add rule <span className="kbd" style={{ background: 'rgba(255,255,255,.15)', borderColor: 'transparent', color: '#fff' }}>↵</span></button>
+        </div>
+      </div>
+
+      <div className="two" style={{ gridTemplateColumns: '1fr 320px' }}>
+        <div className="stack">
+          <div className="between"><div className="h-sec">Your rules <span className="muted" style={{ fontWeight: 400 }}>· {rules.length}</span></div><span className="muted" style={{ fontSize: 12.5 }}>Evaluated top to bottom by specificity</span></div>
+          {rules.map(r => (
+            <div className={`rule-card ${r.enabled ? '' : 'off'}`} key={r.id}>
+              <span className={`effect ${r.effect}`}>{r.effect}</span>
+              <div className="grow">
+                <Sentence effect={r.effect} data={r.data} target={r.target} />
+                {r.note && <div className="muted" style={{ fontSize: 13, marginTop: 4 }}>{r.note}</div>}
+                <div className="row muted" style={{ fontSize: 12, marginTop: 8, gap: 10 }}>
+                  <span className="mono">{r.id}</span>
+                  <span>·</span>
+                  <span className="row" style={{ gap: 5 }}>{r.createdBy === 'agent' ? <><Icon name="sparkle" size={12} />Suggested by the agent</> : <><Icon name="user" size={12} />You</>}</span>
+                  <span>·</span>
+                  <span>{fmtDate(r.createdAt)}</span>
+                  {r.id === 'r-01' && <><span>·</span><span className="row" style={{ gap: 4, color: 'var(--red)' }}><Icon name="lock" size={12} />Always enforced</span></>}
+                </div>
+              </div>
+              <div className="row" style={{ gap: 12 }}>
+                <Toggle on={r.enabled} onChange={() => dispatch({ type: 'toggleRule', id: r.id })} />
+                <button className="muted" onClick={() => dispatch({ type: 'deleteRule', id: r.id })} aria-label="Delete" disabled={r.id === 'r-01'} style={{ opacity: r.id === 'r-01' ? .3 : 1 }}><Icon name="trash" size={16} /></button>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="stack">
+          <div className="h-sec">Suggested by the agent</div>
+          {AGENT_SUGGESTIONS.map(s => (
+            <div className="card pad" key={s.text} style={{ background: 'var(--bg-2)', border: 0 }}>
+              <div className="row" style={{ gap: 8, color: 'var(--ink-3)', fontSize: 12, fontWeight: 600, letterSpacing: '.04em', textTransform: 'uppercase' }}><Icon name="sparkle" size={13} />Suggestion</div>
+              <div style={{ fontWeight: 500, marginTop: 8, letterSpacing: '-0.01em' }}>{s.text}</div>
+              <div className="sub" style={{ fontSize: 13.5, marginTop: 6 }}>{s.why}</div>
+              <button className="btn sm" style={{ marginTop: 12 }} onClick={() => addRule(s.rule, 'agent')}><Icon name="plus" size={13} />Add rule</button>
+            </div>
+          ))}
+          <div className="card pad">
+            <div className="h-sec" style={{ fontSize: 14 }}>How rules resolve</div>
+            <ol className="sub" style={{ fontSize: 13.5, paddingLeft: 18, margin: '8px 0 0', lineHeight: 1.6 }}>
+              <li>Secrets are blocked on every local tool call.</li>
+              <li>Most specific target wins: app › agent › category › everything.</li>
+              <li>On a tie, the stricter effect wins: never › ask › share.</li>
+              <li>No rule? You get asked.</li>
+              <li>Data outside an app's declared scopes is flagged as scope creep.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+function Sentence({ effect, data, target }: Pick<Rule, 'effect' | 'data' | 'target'>) {
+  const verb = { allow: 'Share', ask: 'Ask before sharing', deny: 'Never share' }[effect]
+  return <div className="rule-sentence">{verb} <b>{dataLabel(data)}</b> with <b>{targetLabel(target)}</b></div>
+}

--- a/frontend/src/store/engine.ts
+++ b/frontend/src/store/engine.ts
@@ -1,0 +1,187 @@
+import { APPS, APP_CATEGORIES, DATA } from '../data/mock'
+import { DATA_CATEGORIES } from '../data/types'
+import type {
+  AgentId, App, AppCategoryId, DataCategory, DataItem, Effect, Rule, RuleTarget, Severity,
+} from '../data/types'
+
+export interface FieldVerdict {
+  item: DataItem
+  effect: Effect | 'block'
+  ruleId?: string
+  reason: string
+}
+export interface Flag { severity: Severity; title: string; body: string }
+export interface Evaluation {
+  fields: FieldVerdict[]
+  overall: 'allowed' | 'denied' | 'asked' | 'blocked'
+  flags: Flag[]
+}
+
+const SPECIFICITY: Record<RuleTarget['type'], number> = { all: 0, category: 1, agent: 2, app: 3 }
+const SEVERITY: Record<Effect, number> = { allow: 0, ask: 1, deny: 2 }
+
+function targetMatches(t: RuleTarget, app: App, agent: AgentId) {
+  switch (t.type) {
+    case 'all': return true
+    case 'category': return t.id === app.category
+    case 'app': return t.id === app.id
+    case 'agent': return t.id === agent
+  }
+}
+
+/** Find the rule that governs one data category for an app + agent pair. */
+export function matchRule(category: DataCategory, app: App, agent: AgentId | null, rules: Rule[]): Rule | undefined {
+  const candidates = rules.filter(r =>
+    r.enabled &&
+    (r.data === 'all' || r.data.includes(category)) &&
+    (r.target.type === 'agent' ? agent !== null && targetMatches(r.target, app, agent) : targetMatches(r.target, app, agent ?? 'codex')),
+  )
+  candidates.sort((a, b) =>
+    SPECIFICITY[b.target.type] - SPECIFICITY[a.target.type] || SEVERITY[b.effect] - SEVERITY[a.effect])
+  return candidates[0]
+}
+
+export function evaluate(agent: AgentId, app: App, fieldIds: string[], rules: Rule[]): Evaluation {
+  const flags: Flag[] = []
+  const items = fieldIds.map(id => DATA.find(d => d.id === id)).filter((x): x is DataItem => !!x)
+
+  const fields: FieldVerdict[] = items.map(item => {
+    if (item.category === 'secrets' || item.sensitivity === 'critical') {
+      return { item, effect: 'block', ruleId: 'r-01', reason: 'Secret detected in outbound payload' }
+    }
+    if (app.trust === 'unknown') {
+      return { item, effect: 'block', reason: `${app.name} is not a verified application` }
+    }
+    const rule = matchRule(item.category, app, agent, rules)
+    const scopeCreep = !app.scopes.includes(item.category)
+    if (!rule) {
+      return { item, effect: 'ask', reason: scopeCreep ? `${app.name} never declared the ${DATA_CATEGORIES[item.category].label} scope` : 'No rule covers this data yet' }
+    }
+    if (scopeCreep && rule.effect === 'allow') {
+      return { item, effect: 'ask', ruleId: rule.id, reason: `Allowed by ${rule.id}, but ${app.name} never declared this scope` }
+    }
+    return { item, effect: rule.effect, ruleId: rule.id, reason: describeRule(rule) }
+  })
+
+  const secrets = fields.filter(f => f.effect === 'block')
+  if (secrets.length) {
+    const names = secrets.map(f => f.item.label).join(', ')
+    flags.push({
+      severity: 'critical',
+      title: `Blocked: ${agentLabel(agent)} tried to send ${names} to ${app.name}`,
+      body: app.trust === 'unknown'
+        ? `${app.domain} is not a verified application. The payload was stopped before leaving your machine.`
+        : 'A live credential was found in the outbound payload. The payload was stopped before leaving your machine. Rotate the key if it was pasted anywhere else.',
+    })
+  }
+  const creep = fields.filter(f => f.effect !== 'block' && !app.scopes.includes(f.item.category))
+  if (creep.length && app.trust !== 'unknown') {
+    const cats = [...new Set(creep.map(f => DATA_CATEGORIES[f.item.category].label))].join(', ')
+    flags.push({
+      severity: 'warning',
+      title: `Scope creep: ${app.name} requested ${cats} data`,
+      body: `${app.name} declared only ${app.scopes.map(s => DATA_CATEGORIES[s].label).join(', ') || 'no'} scopes, yet this request included ${cats}. ${creep.some(f => f.effect === 'deny') ? 'The field was denied by your rules and the request was flagged.' : 'Review before approving.'}`,
+    })
+  }
+
+  const overall: Evaluation['overall'] =
+    secrets.length ? 'blocked'
+      : fields.some(f => f.effect === 'ask') ? 'asked'
+        : fields.every(f => f.effect === 'deny') ? 'denied'
+          : 'allowed'
+  return { fields, overall, flags }
+}
+
+export function agentLabel(a: AgentId) {
+  return { codex: 'Codex', 'claude-code': 'Claude Code', chatgpt: 'ChatGPT agent', cursor: 'Cursor' }[a]
+}
+
+export function targetLabel(t: RuleTarget): string {
+  switch (t.type) {
+    case 'all': return 'every app'
+    case 'category': return `${APP_CATEGORIES.find(c => c.id === t.id)?.label ?? t.id} apps`
+    case 'app': return APPS.find(a => a.id === t.id)?.name ?? t.id
+    case 'agent': return `${agentLabel(t.id)} sessions`
+  }
+}
+
+export function dataLabel(data: Rule['data']) {
+  if (data === 'all') return 'any data'
+  return data.map(c => DATA_CATEGORIES[c].label.toLowerCase()).join(' and ')
+}
+
+export function describeRule(r: Rule) {
+  const verb = { allow: 'Share', ask: 'Ask before sharing', deny: 'Never share' }[r.effect]
+  return `${verb} ${dataLabel(r.data)} with ${targetLabel(r.target)}`
+}
+
+/* ---------- plain-language rule parser (mock NLU) ---------- */
+const CATEGORY_WORDS: Record<DataCategory, string[]> = {
+  identity: ['identity', 'name', 'passport', 'birth', 'id document', 'age'],
+  contact: ['contact', 'email', 'phone', 'phone number', 'mail'],
+  location: ['location', 'address', 'where i', 'places', 'travel', 'trip', 'gps', 'position'],
+  financial: ['financial', 'finance', 'money', 'bank', 'iban', 'card', 'payment', 'income', 'salary'],
+  health: ['health', 'medical', 'allerg', 'condition', 'prescription', 'doctor'],
+  preferences: ['preference', 'history', 'habits', 'taste', 'watch', 'purchase', 'search', 'device'],
+  work: ['work', 'job', 'employer', 'repo', 'code', 'company', 'professional'],
+  secrets: ['secret', 'api key', 'token', 'credential', 'password', 'env'],
+}
+const AGENT_WORDS: Record<AgentId, string[]> = {
+  codex: ['codex'], 'claude-code': ['claude'], chatgpt: ['chatgpt', 'gpt'], cursor: ['cursor'],
+}
+
+export function parseRule(text: string): Omit<Rule, 'id' | 'createdAt' | 'enabled' | 'createdBy'> | null {
+  const t = text.toLowerCase().trim()
+  if (t.length < 6) return null
+  let effect: Effect = 'allow'
+  if (/\b(never|don't|do not|block|deny|refuse|no\b|forbid|hide)/.test(t)) effect = 'deny'
+  else if (/\b(ask|confirm|approve|check with me|prompt|review)/.test(t)) effect = 'ask'
+  else if (/\b(allow|let|can|share|ok|permit|give)/.test(t)) effect = 'allow'
+  else return null
+
+  const hasWord = (w: string) => new RegExp(`\\b${w}(s|es|ies)?\\b`).test(t)
+  const data: DataCategory[] = (Object.keys(CATEGORY_WORDS) as DataCategory[])
+    .filter(c => CATEGORY_WORDS[c].some(hasWord))
+  const everything = /\b(anything|everything|all my data|any data|all data)\b/.test(t)
+
+  let target: RuleTarget = { type: 'all' }
+  const app = APPS.find(a => t.includes(a.name.toLowerCase()) || new RegExp(`\\b${a.id}\\b`).test(t))
+  // "social apps", "travel services": the category word followed by a noun wins over a bare word,
+  // so "health data with social apps" targets Social, not Health.
+  const catByPhrase = APP_CATEGORIES.find(c => new RegExp(`\\b${c.label.toLowerCase()}\\s+(apps?|services?|tools?|sites?|platforms?|companies)`).test(t))
+  const catByWord = APP_CATEGORIES.find(c => new RegExp(`\\b${c.label.toLowerCase()}\\b`).test(t) && !(c.id === 'health' && data.includes('health')))
+  const cat = catByPhrase ?? catByWord
+  const agent = (Object.keys(AGENT_WORDS) as AgentId[]).find(a => AGENT_WORDS[a].some(w => t.includes(w)))
+  if (app) target = { type: 'app', id: app.id }
+  else if (cat) target = { type: 'category', id: cat.id as AppCategoryId }
+  else if (agent) target = { type: 'agent', id: agent }
+
+  if (!data.length && !everything) return null
+  return { effect, data: everything && !data.length ? 'all' : data, target, note: text.trim() }
+}
+
+/* ---------- agent explanation for an app ---------- */
+export function explainApp(app: App, rules: Rule[]) {
+  const rows = app.scopes.map(cat => {
+    const rule = matchRule(cat, app, null, rules)
+    const effect: Effect = cat === 'secrets' ? 'deny' : rule?.effect ?? 'ask'
+    return { cat, effect, rule }
+  })
+  const by = (e: Effect) => rows.filter(r => r.effect === e).map(r => DATA_CATEGORIES[r.cat].label.toLowerCase())
+  const allow = by('allow'), ask = by('ask'), deny = by('deny')
+  const catLabel = APP_CATEGORIES.find(c => c.id === app.category)?.label.toLowerCase() ?? app.category
+  const parts: string[] = []
+  parts.push(`${app.name} is a ${app.trust === 'verified' ? 'verified ' : app.trust === 'unknown' ? 'n unverified ' : ' community-listed '}${catLabel} app. It declares ${app.scopes.length} scope${app.scopes.length === 1 ? '' : 's'}.`)
+  if (allow.length) parts.push(`Agents can share your ${list(allow)} with it without asking you, because of your ${catLabel} rules.`)
+  if (ask.length) parts.push(`For ${list(ask)}, you will get a prompt every time an agent tries.`)
+  if (deny.length) parts.push(`Your ${list(deny)} will never be shared with it.`)
+  const notDeclared = (Object.keys(DATA_CATEGORIES) as DataCategory[]).filter(c => !app.scopes.includes(c) && c !== 'secrets')
+  if (notDeclared.length) parts.push(`Anything else (${list(notDeclared.map(c => DATA_CATEGORIES[c].label.toLowerCase()))}) is outside its declared scopes and will be flagged as scope creep if requested.`)
+  parts.push('Secrets such as API keys are blocked on every local tool call, for every app.')
+  return { rows, text: parts.join(' ') }
+}
+
+function list(xs: string[]) {
+  if (xs.length <= 1) return xs.join('')
+  return xs.slice(0, -1).join(', ') + ' and ' + xs[xs.length - 1]
+}

--- a/frontend/src/store/store.tsx
+++ b/frontend/src/store/store.tsx
@@ -1,0 +1,163 @@
+import { createContext, useCallback, useContext, useMemo, useReducer, type ReactNode } from 'react'
+import { ALERTS, APPS, EVENTS, RULES, SCENARIOS, ago } from '../data/mock'
+import type { Alert, App, DataCategory, Rule, Scenario, ShareEvent } from '../data/types'
+import { evaluate, type Evaluation } from './engine'
+
+export interface Pending { scenario: Scenario; evaluation: Evaluation; eventId: string }
+export interface Toast { id: string; title: string; sub?: string; tone?: 'ok' | 'bad' | 'neutral' }
+
+interface State {
+  apps: App[]
+  rules: Rule[]
+  events: ShareEvent[]
+  alerts: Alert[]
+  pending: Pending | null
+  criticalTakeover: Alert | null
+  toasts: Toast[]
+  drawerApp: string | null
+  scenarioCursor: number
+}
+
+type Action =
+  | { type: 'toggleApp'; id: string }
+  | { type: 'toggleScope'; id: string; scope: DataCategory }
+  | { type: 'toggleRule'; id: string }
+  | { type: 'deleteRule'; id: string }
+  | { type: 'addRule'; rule: Rule }
+  | { type: 'simulate' }
+  | { type: 'resolvePending'; decision: 'allow' | 'deny' | 'always' }
+  | { type: 'resolveAlert'; id: string }
+  | { type: 'dismissTakeover' }
+  | { type: 'toast'; toast: Toast }
+  | { type: 'untoast'; id: string }
+  | { type: 'drawer'; id: string | null }
+
+let seq = 200
+const nid = (p: string) => `${p}-${seq++}`
+
+function reducer(s: State, a: Action): State {
+  switch (a.type) {
+    case 'toggleApp':
+      return { ...s, apps: s.apps.map(x => x.id === a.id ? { ...x, connected: !x.connected } : x) }
+    case 'toggleScope':
+      return {
+        ...s, apps: s.apps.map(x => x.id !== a.id ? x : {
+          ...x, scopes: x.scopes.includes(a.scope) ? x.scopes.filter(sc => sc !== a.scope) : [...x.scopes, a.scope],
+        }),
+      }
+    case 'toggleRule':
+      return { ...s, rules: s.rules.map(r => r.id === a.id ? { ...r, enabled: !r.enabled } : r) }
+    case 'deleteRule':
+      return { ...s, rules: s.rules.filter(r => r.id !== a.id) }
+    case 'addRule':
+      return { ...s, rules: [a.rule, ...s.rules] }
+    case 'simulate': {
+      const scenario = SCENARIOS[s.scenarioCursor % SCENARIOS.length]
+      const app = s.apps.find(x => x.id === scenario.app)!
+      const ev = evaluate(scenario.agent, app, scenario.fields, s.rules)
+      const eventId = nid('e')
+      const at = new Date().toISOString()
+      const primary = ev.fields.find(f => f.effect === 'block') ?? ev.fields.find(f => f.effect === 'ask') ?? ev.fields[0]
+      const event: ShareEvent = {
+        id: eventId, at, agent: scenario.agent, session: scenario.session, context: scenario.context,
+        app: scenario.app, fields: scenario.fields,
+        decision: ev.overall === 'asked' ? 'pending' : ev.overall,
+        ruleId: primary?.ruleId, flagged: ev.flags.length > 0, reason: primary?.reason,
+      }
+      const alerts: Alert[] = ev.flags.map(f => ({ id: nid('a'), at, severity: f.severity, title: f.title, body: f.body, eventId, resolved: false }))
+      const critical = alerts.find(x => x.severity === 'critical') ?? null
+      const next: State = {
+        ...s,
+        scenarioCursor: s.scenarioCursor + 1,
+        events: [event, ...s.events],
+        alerts: [...alerts, ...s.alerts],
+        apps: s.apps.map(x => x.id === scenario.app ? { ...x, requests: x.requests + 1, lastAccess: at } : x),
+        criticalTakeover: critical,
+        pending: ev.overall === 'asked' && !critical ? { scenario, evaluation: ev, eventId } : null,
+      }
+      if (ev.overall === 'allowed' || ev.overall === 'denied') {
+        const nAllow = ev.fields.filter(f => f.effect === 'allow').length
+        const nDeny = ev.fields.filter(f => f.effect === 'deny').length
+        const partial = ev.overall === 'allowed' && nDeny > 0
+        if (partial) event.reason = `${nDeny} field${nDeny > 1 ? 's' : ''} denied by ${ev.fields.find(f => f.effect === 'deny')?.ruleId ?? 'your rules'}`
+        next.toasts = [...s.toasts, {
+          id: nid('t'),
+          title: partial ? `Partially shared with ${app.name}` : ev.overall === 'allowed' ? `Shared with ${app.name}` : `Denied for ${app.name}`,
+          sub: partial ? `${nAllow} shared · ${nDeny} denied` : `${scenario.fields.length} field${scenario.fields.length > 1 ? 's' : ''} · rule ${primary?.ruleId ?? '—'}`,
+          tone: ev.overall === 'allowed' ? 'ok' : 'bad',
+        }]
+      }
+      return next
+    }
+    case 'resolvePending': {
+      if (!s.pending) return s
+      const { scenario, evaluation, eventId } = s.pending
+      const app = s.apps.find(x => x.id === scenario.app)!
+      const decision = a.decision === 'deny' ? 'denied' : 'allowed'
+      let rules = s.rules
+      if (a.decision === 'always') {
+        const cats = [...new Set(evaluation.fields.filter(f => f.effect === 'ask').map(f => f.item.category))]
+        rules = [{
+          id: nid('r'), effect: 'allow', data: cats, target: { type: 'app', id: app.id }, enabled: true,
+          createdBy: 'user', note: `Created from a ${scenario.agent} request on ${new Date().toLocaleDateString('en-GB')}`, createdAt: new Date().toISOString(),
+        }, ...s.rules]
+      }
+      return {
+        ...s, rules, pending: null,
+        events: s.events.map(e => e.id === eventId ? { ...e, decision, reason: a.decision === 'always' ? 'You approved and created a rule' : a.decision === 'allow' ? 'You approved once' : 'You declined' } : e),
+        toasts: [...s.toasts, {
+          id: nid('t'),
+          title: decision === 'allowed' ? `Shared with ${app.name}` : `Denied for ${app.name}`,
+          sub: a.decision === 'always' ? 'New rule added' : 'Logged in activity',
+          tone: decision === 'allowed' ? 'ok' : 'bad',
+        }],
+      }
+    }
+    case 'resolveAlert':
+      return { ...s, alerts: s.alerts.map(x => x.id === a.id ? { ...x, resolved: true } : x) }
+    case 'dismissTakeover':
+      return { ...s, criticalTakeover: null }
+    case 'toast':
+      return { ...s, toasts: [...s.toasts, a.toast] }
+    case 'untoast':
+      return { ...s, toasts: s.toasts.filter(t => t.id !== a.id) }
+    case 'drawer':
+      return { ...s, drawerApp: a.id }
+  }
+}
+
+const initial: State = {
+  apps: APPS, rules: RULES, events: EVENTS, alerts: ALERTS,
+  pending: null, criticalTakeover: null, toasts: [], drawerApp: null, scenarioCursor: 0,
+}
+
+interface Ctx extends State {
+  dispatch: (a: Action) => void
+  simulate: () => void
+  addRule: (r: Omit<Rule, 'id' | 'createdAt' | 'enabled' | 'createdBy'>, by?: Rule['createdBy']) => void
+  unresolved: Alert[]
+}
+
+const StoreCtx = createContext<Ctx | null>(null)
+
+export function StoreProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initial)
+  const simulate = useCallback(() => dispatch({ type: 'simulate' }), [])
+  const addRule = useCallback((r: Omit<Rule, 'id' | 'createdAt' | 'enabled' | 'createdBy'>, by: Rule['createdBy'] = 'user') => {
+    dispatch({ type: 'addRule', rule: { ...r, id: nid('r'), enabled: true, createdBy: by, createdAt: new Date().toISOString() } })
+    dispatch({ type: 'toast', toast: { id: nid('t'), title: 'Rule added', sub: 'Applies to the next request', tone: 'neutral' } })
+  }, [])
+  const value = useMemo<Ctx>(() => ({
+    ...state, dispatch, simulate, addRule,
+    unresolved: state.alerts.filter(a => !a.resolved),
+  }), [state, simulate, addRule])
+  return <StoreCtx.Provider value={value}>{children}</StoreCtx.Provider>
+}
+
+export function useStore() {
+  const c = useContext(StoreCtx)
+  if (!c) throw new Error('useStore outside provider')
+  return c
+}
+
+export { ago }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,403 @@
+:root {
+  --bg: #ffffff;
+  --bg-2: #f7f7f8;
+  --bg-3: #efeff3;
+  --ink: #0d0d0d;
+  --ink-2: #4b4b57;
+  --ink-3: #8e8ea0;
+  --line: #ececf1;
+  --line-2: #d9d9e3;
+  --green: #10a37f;
+  --green-bg: #e6f6f1;
+  --red: #e5484d;
+  --red-bg: #fdecec;
+  --amber: #d98d0b;
+  --amber-bg: #fcf3e0;
+  --blue: #3b6cf6;
+  --blue-bg: #e9eefe;
+  --radius: 16px;
+  --radius-sm: 10px;
+  --radius-xs: 6px;
+  --pill: 999px;
+  --font: 'Hanken Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --shadow: 0 1px 2px rgba(13,13,13,.04), 0 8px 24px -12px rgba(13,13,13,.12);
+  --shadow-lg: 0 2px 4px rgba(13,13,13,.04), 0 24px 60px -20px rgba(13,13,13,.25);
+  --ease: cubic-bezier(.2,.7,.2,1);
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: 'ss01', 'cv11';
+}
+a { color: inherit; text-decoration: none; }
+button { font: inherit; color: inherit; cursor: pointer; background: none; border: 0; padding: 0; }
+input, textarea { font: inherit; color: inherit; }
+h1, h2, h3, h4, p { margin: 0; }
+h1, h2, h3, h4 { font-weight: 500; letter-spacing: -0.025em; }
+::selection { background: var(--ink); color: #fff; }
+.mono { font-family: var(--mono); font-size: 13px; letter-spacing: -0.01em; }
+.muted { color: var(--ink-3); }
+.sub { color: var(--ink-2); }
+
+/* ---------- primitives ---------- */
+.btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  height: 40px; padding: 0 18px; border-radius: var(--pill);
+  font-size: 14px; font-weight: 500; letter-spacing: -0.005em;
+  background: var(--ink); color: #fff; border: 1px solid var(--ink);
+  transition: transform .15s var(--ease), background .15s, border-color .15s, color .15s, opacity .15s;
+  white-space: nowrap;
+}
+.btn:hover { background: #2a2a30; border-color: #2a2a30; }
+.btn:active { transform: scale(.98); }
+.btn.ghost { background: transparent; color: var(--ink); border-color: var(--line-2); }
+.btn.ghost:hover { background: var(--bg-2); border-color: var(--ink-3); }
+.btn.soft { background: var(--bg-2); color: var(--ink); border-color: transparent; }
+.btn.soft:hover { background: var(--bg-3); }
+.btn.danger { background: var(--red); border-color: var(--red); }
+.btn.danger:hover { background: #cf3a40; border-color: #cf3a40; }
+.btn.green { background: var(--green); border-color: var(--green); }
+.btn.green:hover { background: #0e8f70; border-color: #0e8f70; }
+.btn.sm { height: 32px; padding: 0 12px; font-size: 13px; }
+.btn.lg { height: 48px; padding: 0 24px; font-size: 15px; }
+.btn:disabled { opacity: .5; cursor: not-allowed; }
+
+.tag {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 24px; padding: 0 9px; border-radius: var(--pill);
+  font-size: 12px; font-weight: 500; letter-spacing: 0;
+  background: var(--bg-2); color: var(--ink-2); border: 1px solid transparent;
+  white-space: nowrap;
+}
+.tag.outline { background: transparent; border-color: var(--line-2); }
+.tag.green { background: var(--green-bg); color: #0b7a5f; }
+.tag.red { background: var(--red-bg); color: #b5232a; }
+.tag.amber { background: var(--amber-bg); color: #8a5a06; }
+.tag.blue { background: var(--blue-bg); color: #2a4fc0; }
+.tag.dark { background: var(--ink); color: #fff; }
+.tag .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+.card {
+  background: var(--bg); border: 1px solid var(--line); border-radius: var(--radius);
+}
+.card.pad { padding: 20px; }
+.card.soft { background: var(--bg-2); border-color: transparent; }
+
+.toggle {
+  position: relative; width: 38px; height: 22px; border-radius: var(--pill);
+  background: var(--line-2); transition: background .2s; flex: none;
+}
+.toggle::after {
+  content: ''; position: absolute; top: 2px; left: 2px; width: 18px; height: 18px;
+  border-radius: 50%; background: #fff; transition: transform .2s var(--ease);
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+}
+.toggle.on { background: var(--ink); }
+.toggle.on::after { transform: translateX(16px); }
+.toggle.green.on { background: var(--green); }
+
+.avatar {
+  width: 36px; height: 36px; border-radius: 10px; display: grid; place-items: center;
+  font-weight: 600; font-size: 14px; letter-spacing: -0.02em; color: #fff; flex: none;
+}
+.avatar.sm { width: 28px; height: 28px; border-radius: 8px; font-size: 12px; }
+.avatar.lg { width: 48px; height: 48px; border-radius: 14px; font-size: 18px; }
+
+.field {
+  display: flex; align-items: center; gap: 10px; height: 40px; padding: 0 14px;
+  border: 1px solid var(--line-2); border-radius: var(--pill); background: var(--bg);
+  transition: border-color .15s, box-shadow .15s;
+}
+.field:focus-within { border-color: var(--ink); box-shadow: 0 0 0 3px rgba(13,13,13,.06); }
+.field input { border: 0; outline: 0; background: transparent; flex: 1; min-width: 0; }
+.field input::placeholder { color: var(--ink-3); }
+
+.seg { display: inline-flex; gap: 2px; padding: 3px; background: var(--bg-2); border-radius: var(--pill); }
+.seg button { height: 30px; padding: 0 12px; border-radius: var(--pill); font-size: 13px; font-weight: 500; color: var(--ink-2); transition: all .15s; }
+.seg button:hover { color: var(--ink); }
+.seg button.on { background: #fff; color: var(--ink); box-shadow: 0 1px 2px rgba(0,0,0,.08); }
+
+.chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.chip {
+  display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 12px;
+  border-radius: var(--pill); border: 1px solid var(--line-2); font-size: 13px; font-weight: 500;
+  color: var(--ink-2); background: #fff; transition: all .15s;
+}
+.chip:hover { border-color: var(--ink-3); color: var(--ink); }
+.chip.on { background: var(--ink); color: #fff; border-color: var(--ink); }
+
+.kbd { font-family: var(--mono); font-size: 11px; padding: 1px 6px; border-radius: 5px; border: 1px solid var(--line-2); background: var(--bg-2); color: var(--ink-2); }
+
+.row { display: flex; align-items: center; gap: 12px; }
+.between { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.stack { display: flex; flex-direction: column; gap: 12px; }
+.grow { flex: 1; min-width: 0; }
+.trunc { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.eyebrow { font-size: 12px; font-weight: 600; letter-spacing: .08em; text-transform: uppercase; color: var(--ink-3); }
+.h-page { font-size: 26px; font-weight: 500; letter-spacing: -0.03em; }
+.h-sec { font-size: 17px; font-weight: 600; letter-spacing: -0.02em; }
+
+.divider { height: 1px; background: var(--line); }
+
+@keyframes rise { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: none; } }
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes pulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(229,72,77,.45); } 70% { box-shadow: 0 0 0 10px rgba(229,72,77,0); } }
+@keyframes pulse-ring { 0% { transform: scale(1); opacity: .6 } 100% { transform: scale(2.4); opacity: 0 } }
+.rise { animation: rise .6s var(--ease) both; }
+.d1 { animation-delay: .05s } .d2 { animation-delay: .12s } .d3 { animation-delay: .2s } .d4 { animation-delay: .3s } .d5 { animation-delay: .4s } .d6 { animation-delay: .5s }
+
+/* ---------- marketing ---------- */
+.mk-nav {
+  position: sticky; top: 0; z-index: 40; height: 64px;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 32px; background: rgba(255,255,255,.8); backdrop-filter: saturate(180%) blur(14px);
+  border-bottom: 1px solid transparent; transition: border-color .2s;
+}
+.mk-nav.scrolled { border-bottom-color: var(--line); }
+.mk-nav nav { display: flex; gap: 28px; font-size: 14px; font-weight: 500; color: var(--ink-2); }
+.mk-nav nav a:hover { color: var(--ink); }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 600; font-size: 17px; letter-spacing: -0.02em; }
+.brand-mark { width: 28px; height: 28px; border-radius: 8px; background: var(--ink); display: grid; place-items: center; flex: none; }
+.brand-mark svg { display: block; }
+
+.wrap { max-width: 1180px; margin: 0 auto; padding: 0 32px; }
+.hero { padding: 96px 0 64px; }
+.hero h1 {
+  font-size: clamp(44px, 6.4vw, 84px); line-height: .98; letter-spacing: -0.04em; font-weight: 500; max-width: 15ch;
+}
+.hero p.lead { font-size: 20px; line-height: 1.45; color: var(--ink-2); max-width: 52ch; margin-top: 28px; letter-spacing: -0.01em; }
+.hero-cta { display: flex; gap: 12px; margin-top: 36px; }
+.hero-grid { display: grid; grid-template-columns: 1.1fr .9fr; gap: 48px; align-items: center; }
+
+.section { padding: 96px 0; }
+.section h2 { font-size: clamp(32px, 4vw, 48px); line-height: 1.05; letter-spacing: -0.035em; max-width: 22ch; }
+.section .lead { font-size: 18px; color: var(--ink-2); max-width: 56ch; margin-top: 16px; }
+
+.steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-top: 56px; }
+.step { padding: 28px; border-radius: 20px; background: var(--bg-2); min-height: 260px; display: flex; flex-direction: column; }
+.step .num { font-family: var(--mono); font-size: 13px; color: var(--ink-3); }
+.step h3 { font-size: 22px; margin-top: auto; letter-spacing: -0.025em; }
+.step p { color: var(--ink-2); margin-top: 8px; }
+
+.feat-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; margin-top: 56px; }
+.feat { border: 1px solid var(--line); border-radius: 24px; padding: 32px; overflow: hidden; position: relative; min-height: 380px; display: flex; flex-direction: column; gap: 24px; }
+.feat h3 { font-size: 22px; letter-spacing: -0.025em; }
+.feat p { color: var(--ink-2); margin-top: 6px; max-width: 44ch; }
+.feat .preview { margin-top: auto; border-radius: 14px; border: 1px solid var(--line); background: var(--bg-2); padding: 16px; }
+
+.logos { display: flex; flex-wrap: wrap; gap: 12px 40px; align-items: center; margin-top: 32px; color: var(--ink-2); font-weight: 600; font-size: 18px; letter-spacing: -0.02em; }
+.logos span { display: inline-flex; align-items: center; gap: 8px; }
+
+.code {
+  background: var(--ink); color: #e8e8ee; border-radius: 20px; padding: 24px 28px; font-family: var(--mono); font-size: 13px; line-height: 1.7; overflow-x: auto; white-space: pre;
+}
+.code .c { color: #7d7d8c; } .code .g { color: #3fd0a8; } .code .y { color: #f3c969; } .code .p { color: #a6b4ff; }
+
+.footer { border-top: 1px solid var(--line); padding: 40px 0; color: var(--ink-3); font-size: 13px; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; }
+
+/* flow visual */
+.flow { position: relative; height: 420px; border-radius: 28px; background: var(--bg-2); overflow: hidden; }
+.flow .col { position: absolute; top: 0; bottom: 0; display: flex; flex-direction: column; justify-content: center; gap: 10px; }
+.flow .col.left { left: 28px; } .flow .col.right { right: 28px; align-items: flex-end; }
+.flow .node { display: inline-flex; align-items: center; gap: 8px; height: 34px; padding: 0 12px; background: #fff; border: 1px solid var(--line); border-radius: var(--pill); font-size: 13px; font-weight: 500; white-space: nowrap; box-shadow: 0 1px 2px rgba(0,0,0,.03); }
+.flow .node .src { font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+.flow .gate { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 150px; padding: 14px; background: var(--ink); color: #fff; border-radius: 18px; box-shadow: var(--shadow-lg); text-align: center; }
+.flow .gate .t { font-weight: 600; font-size: 13px; letter-spacing: -0.01em; }
+.flow .gate .s { font-family: var(--mono); font-size: 10.5px; color: #a5a5b5; margin-top: 4px; }
+.flow .gate .rule { margin-top: 10px; font-size: 11px; background: rgba(255,255,255,.08); border-radius: 8px; padding: 6px 8px; text-align: left; line-height: 1.35; }
+.flow .rule b { color: #3fd0a8; font-weight: 600; }
+.flow svg.lines { position: absolute; inset: 0; width: 100%; height: 100%; }
+.flow .packet { position: absolute; width: 10px; height: 10px; border-radius: 50%; background: var(--ink); offset-rotate: 0deg; }
+.flow .packet.ok { background: var(--green); }
+.flow .packet.blocked { background: var(--red); }
+.flow .label { position: absolute; font-family: var(--mono); font-size: 11px; color: var(--ink-3); }
+
+/* ---------- app shell ---------- */
+.shell { display: grid; grid-template-columns: 248px 1fr; min-height: 100vh; }
+.side { border-right: 1px solid var(--line); padding: 20px 16px; display: flex; flex-direction: column; gap: 6px; position: sticky; top: 0; height: 100vh; background: var(--bg); }
+.side .brand { padding: 6px 10px 18px; }
+.side .nav-label { padding: 14px 10px 6px; }
+.navi {
+  display: flex; align-items: center; gap: 10px; height: 38px; padding: 0 10px; border-radius: var(--radius-sm);
+  font-size: 14px; font-weight: 500; color: var(--ink-2); transition: background .12s, color .12s; white-space: nowrap;
+}
+.navi:hover { background: var(--bg-2); color: var(--ink); }
+.navi.active { background: var(--bg-2); color: var(--ink); }
+.navi .count { margin-left: auto; white-space: nowrap; font-family: var(--mono); font-size: 11.5px; color: var(--ink-3); }
+.navi .count.red { color: var(--red); font-weight: 600; }
+.side .me { margin-top: auto; padding: 12px 10px; display: flex; align-items: center; gap: 10px; border-top: 1px solid var(--line); }
+
+.main { min-width: 0; display: flex; flex-direction: column; }
+.topbar { height: 64px; display: flex; align-items: center; gap: 12px; padding: 0 32px; border-bottom: 1px solid var(--line); position: sticky; top: 0; background: rgba(255,255,255,.85); backdrop-filter: blur(12px); z-index: 20; }
+.topbar .crumb { font-size: 14px; color: var(--ink-3); display: flex; gap: 8px; align-items: center; }
+.topbar .crumb b { color: var(--ink); font-weight: 500; }
+.content { padding: 32px; display: flex; flex-direction: column; gap: 28px; max-width: 1240px; width: 100%; }
+.page-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; }
+.page-head p { color: var(--ink-2); margin-top: 6px; max-width: 64ch; }
+
+.bell { position: relative; width: 40px; height: 40px; border-radius: var(--pill); display: grid; place-items: center; border: 1px solid var(--line-2); }
+.bell:hover { background: var(--bg-2); }
+.bell .n { position: absolute; top: -4px; right: -4px; min-width: 18px; height: 18px; padding: 0 5px; border-radius: var(--pill); background: var(--red); color: #fff; font-size: 11px; font-weight: 600; display: grid; place-items: center; }
+
+/* banner */
+.banner {
+  display: flex; align-items: center; gap: 14px; padding: 14px 20px; border-radius: 14px;
+  background: var(--ink); color: #fff; animation: pop .4s var(--ease) both;
+}
+.banner.critical { background: var(--red); }
+.banner .pulse { width: 10px; height: 10px; border-radius: 50%; background: #fff; position: relative; flex: none; }
+.banner .pulse::after { content: ''; position: absolute; inset: 0; border-radius: 50%; background: #fff; animation: pulse-ring 1.4s ease-out infinite; }
+.banner b { font-weight: 600; }
+.banner .btn { height: 32px; padding: 0 12px; font-size: 13px; background: #fff; color: var(--ink); border-color: #fff; }
+.banner .btn:hover { background: #f0f0f3; }
+
+/* stats */
+.stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+.stat { padding: 20px; border: 1px solid var(--line); border-radius: var(--radius); display: flex; flex-direction: column; gap: 14px; min-height: 128px; }
+.stat .label { font-size: 13px; color: var(--ink-2); font-weight: 500; }
+.stat .val { font-size: 34px; font-weight: 500; letter-spacing: -0.04em; line-height: 1; margin-top: auto; }
+.stat .delta { font-size: 12.5px; color: var(--ink-3); }
+.stat .delta.red { color: var(--red); }
+.stat .delta.green { color: var(--green); }
+
+.two { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr); gap: 20px; }
+.three { display: grid; grid-template-columns: 230px minmax(0, 1fr); gap: 20px; align-items: start; }
+
+/* lists */
+.list { display: flex; flex-direction: column; }
+.list > * + * { border-top: 1px solid var(--line); }
+.item { display: flex; align-items: center; gap: 14px; padding: 14px 18px; transition: background .12s; }
+.item.clickable { cursor: pointer; }
+.item.clickable:hover { background: var(--bg-2); }
+.item .t { font-weight: 500; letter-spacing: -0.01em; }
+.item .s { font-size: 13px; color: var(--ink-3); margin-top: 2px; }
+.item.flag { box-shadow: inset 3px 0 0 var(--red); }
+
+/* table */
+table.tbl { width: 100%; border-collapse: collapse; font-size: 14px; }
+.tbl th { text-align: left; font-size: 12px; font-weight: 600; color: var(--ink-3); letter-spacing: .04em; text-transform: uppercase; padding: 10px 12px; border-bottom: 1px solid var(--line); white-space: nowrap; }
+.tbl td { padding: 11px 12px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+.tbl tr:last-child td { border-bottom: 0; }
+.tbl tr:hover td { background: var(--bg-2); }
+.sens { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; color: var(--ink-2); font-weight: 500; }
+.sens i { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.sens.low i { background: var(--line-2); } .sens.medium i { background: var(--amber); } .sens.high i { background: #f0742e; } .sens.critical i { background: var(--red); }
+
+/* app cards */
+.cat-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+.cat { display: flex; flex-direction: column; gap: 14px; padding: 16px; border: 1px solid var(--line); border-radius: var(--radius); text-align: left; transition: all .15s; min-height: 108px; }
+.cat:hover { border-color: var(--ink-3); }
+.cat.on { border-color: var(--ink); background: var(--bg-2); }
+.cat .ic { width: 32px; height: 32px; border-radius: 9px; background: var(--bg-2); display: grid; place-items: center; }
+.cat.on .ic { background: #fff; }
+.cat .n { font-weight: 600; letter-spacing: -0.01em; }
+.cat .c { font-size: 12.5px; color: var(--ink-3); }
+
+.app-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+.app-card { border: 1px solid var(--line); border-radius: var(--radius); padding: 18px; display: flex; flex-direction: column; gap: 14px; }
+.app-card .desc { font-size: 13.5px; color: var(--ink-2); }
+.scopes { display: flex; flex-wrap: wrap; gap: 6px; }
+.scope { display: inline-flex; align-items: center; gap: 6px; height: 28px; padding: 0 10px; border-radius: var(--pill); border: 1px solid var(--line-2); font-size: 12.5px; font-weight: 500; color: var(--ink-2); transition: all .12s; }
+.scope:hover { border-color: var(--ink-3); }
+.scope.allow { background: var(--green-bg); border-color: transparent; color: #0b7a5f; }
+.scope.ask { background: var(--amber-bg); border-color: transparent; color: #8a5a06; }
+.scope.deny { background: var(--red-bg); border-color: transparent; color: #b5232a; }
+.scope.off { opacity: .55; text-decoration: line-through; }
+
+/* rules */
+.rule-card { border: 1px solid var(--line); border-radius: var(--radius); padding: 16px 18px; display: flex; gap: 16px; align-items: flex-start; }
+.rule-card.off { opacity: .55; }
+.effect { width: 64px; flex: none; text-align: center; padding: 6px 0; border-radius: 8px; font-size: 12px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+.effect.allow { background: var(--green-bg); color: #0b7a5f; }
+.effect.ask { background: var(--amber-bg); color: #8a5a06; }
+.effect.deny { background: var(--red-bg); color: #b5232a; }
+.rule-sentence { font-size: 15px; letter-spacing: -0.01em; line-height: 1.45; }
+.rule-sentence b { font-weight: 600; padding: 1px 6px; border-radius: 6px; background: var(--bg-2); }
+.composer { border: 1px solid var(--line); border-radius: 20px; padding: 20px; background: linear-gradient(180deg, #fff, var(--bg-2)); }
+.composer textarea { width: 100%; border: 0; outline: 0; background: transparent; resize: none; font-size: 18px; letter-spacing: -0.015em; line-height: 1.4; min-height: 56px; }
+.composer textarea::placeholder { color: var(--ink-3); }
+.preview-rule { border: 1px dashed var(--line-2); border-radius: 12px; padding: 12px 14px; background: #fff; }
+
+/* activity */
+.event { display: grid; grid-template-columns: 92px 150px 1fr 190px 120px; gap: 14px; align-items: center; padding: 14px 18px; cursor: pointer; }
+.event:hover { background: var(--bg-2); }
+.event .time { font-family: var(--mono); font-size: 12px; color: var(--ink-3); }
+.event .ctx { font-size: 13px; color: var(--ink-3); margin-top: 2px; }
+.event-detail { padding: 0 18px 18px 18px; background: var(--bg-2); animation: fade .2s both; }
+.agent { display: inline-flex; align-items: center; gap: 8px; font-weight: 500; font-size: 13.5px; }
+.agent .ic { width: 24px; height: 24px; border-radius: 7px; display: grid; place-items: center; background: var(--ink); color: #fff; font-size: 11px; font-weight: 700; }
+.agent .ic.codex { background: #0d0d0d; } .agent .ic.claude { background: #d97757; } .agent .ic.chatgpt { background: var(--green); } .agent .ic.cursor { background: #3b3b45; }
+.decision { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; font-weight: 600; }
+.decision i { width: 8px; height: 8px; border-radius: 50%; }
+.decision.allowed { color: #0b7a5f; } .decision.allowed i { background: var(--green); }
+.decision.denied { color: #b5232a; } .decision.denied i { background: var(--red); }
+.decision.blocked { color: #b5232a; } .decision.blocked i { background: var(--red); box-shadow: 0 0 0 3px var(--red-bg); }
+.decision.asked { color: #8a5a06; } .decision.asked i { background: var(--amber); }
+.decision.pending { color: var(--ink-3); } .decision.pending i { background: var(--ink-3); }
+
+/* alerts */
+.alert-card { border: 1px solid var(--line); border-radius: var(--radius); padding: 20px; display: grid; grid-template-columns: 40px 1fr auto; gap: 16px; align-items: start; }
+.alert-card.critical { border-color: rgba(229,72,77,.4); background: linear-gradient(180deg, #fff, #fff7f7); }
+.alert-card.resolved { opacity: .6; }
+.sev { width: 40px; height: 40px; border-radius: 12px; display: grid; place-items: center; }
+.sev.critical { background: var(--red); color: #fff; animation: pulse 1.8s ease-out infinite; }
+.sev.warning { background: var(--amber-bg); color: var(--amber); }
+.sev.info { background: var(--blue-bg); color: var(--blue); }
+
+/* modal */
+.overlay { position: fixed; inset: 0; background: rgba(13,13,13,.45); backdrop-filter: blur(6px); display: grid; place-items: center; z-index: 100; animation: fade .2s both; padding: 20px; }
+.modal { width: 100%; max-width: 520px; background: #fff; border-radius: 24px; box-shadow: var(--shadow-lg); animation: pop .3s var(--ease) both; overflow: hidden; }
+.modal .head { padding: 24px 24px 0; }
+.modal .body { padding: 20px 24px; }
+.modal .foot { padding: 16px 24px 24px; display: flex; gap: 10px; justify-content: flex-end; }
+.modal.critical { border: 2px solid var(--red); }
+.consent-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 0; border-top: 1px solid var(--line); }
+.consent-row:first-child { border-top: 0; }
+.big-x { width: 56px; height: 56px; border-radius: 16px; background: var(--red); color: #fff; display: grid; place-items: center; animation: pulse 1.6s ease-out infinite; }
+
+/* toast */
+.toasts { position: fixed; right: 24px; bottom: 24px; display: flex; flex-direction: column; gap: 10px; z-index: 90; }
+.toast { display: flex; align-items: center; gap: 12px; padding: 12px 16px; background: var(--ink); color: #fff; border-radius: 14px; box-shadow: var(--shadow-lg); font-size: 14px; animation: pop .3s var(--ease) both; max-width: 420px; }
+.toast .s { color: #b6b6c4; font-size: 12.5px; }
+
+/* drawer */
+.drawer { position: fixed; top: 0; right: 0; bottom: 0; width: 460px; background: #fff; border-left: 1px solid var(--line); box-shadow: var(--shadow-lg); z-index: 95; display: flex; flex-direction: column; animation: slide .3s var(--ease) both; }
+@keyframes slide { from { transform: translateX(30px); opacity: 0 } to { transform: none; opacity: 1 } }
+.drawer .dh { padding: 20px 24px; border-bottom: 1px solid var(--line); display: flex; align-items: center; gap: 12px; }
+.drawer .db { padding: 24px; overflow: auto; display: flex; flex-direction: column; gap: 20px; }
+.explain { border-radius: 16px; background: var(--bg-2); padding: 18px; font-size: 15px; line-height: 1.55; letter-spacing: -0.01em; }
+.explain b { font-weight: 600; }
+.explain .who { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--ink-3); margin-bottom: 10px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
+
+.bar { height: 6px; border-radius: 3px; background: var(--bg-3); overflow: hidden; }
+.bar i { display: block; height: 100%; background: var(--ink); border-radius: 3px; }
+
+.empty { padding: 48px; text-align: center; color: var(--ink-3); }
+
+@media (max-width: 1100px) {
+  .stats { grid-template-columns: repeat(2, 1fr); }
+  .cat-grid { grid-template-columns: repeat(2, 1fr); }
+  .two, .three { grid-template-columns: 1fr; }
+  .app-grid, .feat-grid { grid-template-columns: 1fr; }
+  .hero-grid { grid-template-columns: 1fr; }
+  .steps { grid-template-columns: 1fr; }
+  .event { grid-template-columns: 80px 1fr; }
+  .event > :nth-child(n+3) { grid-column: 1 / -1; }
+}
+@media (max-width: 860px) {
+  .shell { grid-template-columns: 1fr; }
+  .side { display: none; }
+  .mk-nav nav { display: none; }
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, loadEnv } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Relative base so the built `dist/` can be served from any path, including
+// straight out of `local_ui_server.py`'s static routes later on.
+// Dev server stays on localhost only (CLAUDE.md I2: nothing beyond 127.0.0.1).
+// `/api/*` is proxied to the local audit server when VITE_API_TARGET is set,
+// e.g. VITE_API_TARGET=http://127.0.0.1:51234 (the URL `$privacy` prints).
+export default defineConfig(({ mode }) => {
+  const target = loadEnv(mode, '.', 'VITE_').VITE_API_TARGET
+  return {
+    plugins: [react()],
+    base: './',
+    server: {
+      port: 5173,
+      proxy: target ? { '/api': { target, changeOrigin: false } } : undefined,
+    },
+  }
+})


### PR DESCRIPTION
## What

Adds `frontend/`, a Vite + React + TypeScript web UI for the Level 2 / Level 3 audit surfaces and the consent prompt of the live block flow, styled after openai.com (white ground, near-black ink, hairline borders, pill buttons; green only for *allowed*, red only for *blocked*).

It sits next to the existing `ui/` folder and does not touch it. `ui/index.html` + `ui/app.js` remain what the `$privacy` skill serves.

## Status, stated plainly

**Prototype on mock data. Not wired.** Nothing in `frontend/` reads the ledger, calls `/api/*`, or talks to the daemon. All screens run on `src/data/mock.ts` and a small in-browser decision engine so the flows can be demoed end to end. `frontend/README.md` maps each screen onto the existing `local_ui_server.py` endpoints (`/api/summary`, `/api/exposures`, `/api/detail`, `/api/policy`, `/api/clean_session`) and calls out what has no counterpart yet (alerts, data vault, destination catalogue). Wiring is intentionally left for a separate change.

## Screens

- **Landing** explaining the model: data → policy gate → agents and destinations, with an animated flow visual.
- **Overview**: counts, recent flows, open alerts, one agent suggestion.
- **Data vault**: fields with provenance (websites, Codex / Claude Code sessions, browser extension), sensitivity, collected date, masked values.
- **Destinations by category**: declared scopes coloured by the effective policy, an "Explain" drawer that spells out what a destination can receive and why.
- **Rules**: plain-language composer (keyword parser, e.g. "Never share my health data with social apps"), rule list with specificity order, agent suggestions.
- **Activity**: flow log with agent, session, destination, fields, decision, matching rule; raw request JSON on expand.
- **Alerts**: critical / warning / info with a resolve action.

"Simulate agent request" (top bar) cycles through scenarios: a consent modal for Booking.com, an "Always allow" that writes an app-scoped rule, a red takeover when a Codex session tries to send `OPENAI_API_KEY` to an unverified paste site, a partial share with a scope-creep warning for Netflix.

## Repo rules checked

- Dev server binds localhost only (I2). `base: './'` so `dist/` can later be served from `local_ui_server.py`'s static routes.
- User-facing copy contains no "undo", "revoke", "remove from context", "your data is protected" or "100% secure" (I5); the README repeats that disclosed data cannot be recalled.
- No claim of complete enforcement; "secrets blocked" is worded as "on every local tool call".
- No attribution trailers in the commit (hook enabled via `core.hooksPath`).

## Run

```bash
cd frontend
npm install
npm run dev      # http://localhost:5173
npm run build    # type-check + bundle
```

## Notes for review

- The visual language is deliberately different from `ui/`'s terminal-native dark theme; treat it as a proposal for the web surface, not a replacement of the ASCII fallback.
- `root/.gitignore` already covers `node_modules/` and `dist/`; `frontend/.gitignore` adds `.vite` and `*.tsbuildinfo`.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a complete React-based web UI prototype for a privacy management system that sits between user data and AI agents/applications. The prototype runs entirely on mock data with no backend integration, showcasing seven main screens: a landing page explaining the model, an overview dashboard, a data vault showing collected information with provenance, an app catalogue with declared scopes and effective policies, a plain-language rule composer, an activity log of share events, and an alerts system. The UI implements a client-side decision engine that evaluates sharing requests against rules, demonstrates consent prompts for ambiguous cases, and shows blocking flows for critical scenarios like leaked secrets. Built with Vite, React, TypeScript, and React Router, it includes a complete design system styled after openai.com (white background, dark text, pill buttons, color-coded decisions). The implementation deliberately avoids prohibited language like "undo" or "100% secure" and binds the dev server to localhost only. All data flows, rule parsing, and policy evaluation are functional in-browser simulations intended to validate UX flows before backend wiring.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `frontend/README.md` |
| 2 | `frontend/package.json` |
| 3 | `frontend/vite.config.ts` |
| 4 | `frontend/tsconfig.json` |
| 5 | `frontend/index.html` |
| 6 | `frontend/src/data/types.ts` |
| 7 | `frontend/src/data/mock.ts` |
| 8 | `frontend/src/store/engine.ts` |
| 9 | `frontend/src/store/store.tsx` |
| 10 | `frontend/src/components/ui.tsx` |
| 11 | `frontend/src/components/Icon.tsx` |
| 12 | `frontend/src/components/Overlays.tsx` |
| 13 | `frontend/src/components/Shell.tsx` |
| 14 | `frontend/src/pages/Landing.tsx` |
| 15 | `frontend/src/pages/Overview.tsx` |
| 16 | `frontend/src/pages/Data.tsx` |
| 17 | `frontend/src/pages/Apps.tsx` |
| 18 | `frontend/src/pages/Rules.tsx` |
| 19 | `frontend/src/pages/Activity.tsx` |
| 20 | `frontend/src/pages/Alerts.tsx` |
| 21 | `frontend/src/App.tsx` |
| 22 | `frontend/src/main.tsx` |
| 23 | `frontend/src/lib/format.ts` |
| 24 | `frontend/src/styles/global.css` |
| 25 | `frontend/.gitignore` |
| 26 | `frontend/tsconfig.app.json` |
| 27 | `frontend/tsconfig.node.json` |
| 28 | `frontend/package-lock.json` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->